### PR TITLE
Compression uses generics to allow better JIT codegen for structs

### DIFF
--- a/source/gfoidl.DataCompression/Compression.cs
+++ b/source/gfoidl.DataCompression/Compression.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace gfoidl.DataCompression
 {
@@ -11,14 +10,15 @@ namespace gfoidl.DataCompression
         /// <summary>
         /// Performs the compression / filtering of the input data.
         /// </summary>
+        /// <typeparam name="TList">The type of the enumeration / list.</typeparam>
         /// <param name="data">Input data</param>
         /// <returns>The compressed / filtered data.</returns>
         /// <exception cref="ArgumentNullException">
         /// <paramref name="data" /> is <c>null</c>.
         /// </exception>
-        public IEnumerable<DataPoint> Process(IEnumerable<DataPoint> data)
+        public IEnumerable<DataPoint> Process<TList>(in TList data) where TList : IEnumerable<DataPoint>
         {
-            if (data == null) throw new ArgumentNullException(nameof(data));
+            if (EqualityComparer<TList>.Default.Equals(data, default)) ThrowHelper.ThrowArgumentNull(nameof(data));
 
             return this.ProcessCore(data);
         }
@@ -26,8 +26,9 @@ namespace gfoidl.DataCompression
         /// <summary>
         /// Implementation of the compression / filtering.
         /// </summary>
+        /// <typeparam name="TList">The type of the enumeration / list.</typeparam>
         /// <param name="data">Input data</param>
         /// <returns>The compressed / filtered data.</returns>
-        protected abstract IEnumerable<DataPoint> ProcessCore(IEnumerable<DataPoint> data);
+        protected abstract IEnumerable<DataPoint> ProcessCore<TList>(in TList data) where TList : IEnumerable<DataPoint>;
     }
 }

--- a/source/gfoidl.DataCompression/Compression/DeadBandCompression.cs
+++ b/source/gfoidl.DataCompression/Compression/DeadBandCompression.cs
@@ -55,23 +55,24 @@ namespace gfoidl.DataCompression
         /// (Absolut) precision of the instrument. Cf. ExDev in documentation.
         /// </param>
         /// <param name="maxTime">Length of time before for sure a value gets recoreded</param>
-        public DeadBandCompression(double instrumentPrecision, TimeSpan maxTime)
+        public DeadBandCompression(double instrumentPrecision, in TimeSpan maxTime)
         : this(instrumentPrecision, maxTime.Ticks)
         { }
         //---------------------------------------------------------------------
         /// <summary>
         /// Implementation of the compression / filtering.
         /// </summary>
+        /// <typeparam name="TList">The type of the enumeration / list.</typeparam>
         /// <param name="data">Input data</param>
         /// <returns>The compressed / filtered data.</returns>
-        protected override IEnumerable<DataPoint> ProcessCore(IEnumerable<DataPoint> data)
+        protected override IEnumerable<DataPoint> ProcessCore<TList>(in TList data)
         {
-            if (data is IList<DataPoint> list) return this.ProcessCore(list);
+            if (data is IList<DataPoint> list) return this.ProcessCoreImpl(list);
 
-            return this.ProcessCore(data.GetEnumerator());
+            return this.ProcessCoreImpl(data.GetEnumerator());
         }
         //---------------------------------------------------------------------
-        private IEnumerable<DataPoint> ProcessCore(IEnumerator<DataPoint> dataEnumerator)
+        private IEnumerable<DataPoint> ProcessCoreImpl(IEnumerator<DataPoint> dataEnumerator)
         {
             if (!dataEnumerator.MoveNext()) yield break;
 
@@ -105,7 +106,7 @@ namespace gfoidl.DataCompression
                 yield return incoming;
         }
         //---------------------------------------------------------------------
-        private IEnumerable<DataPoint> ProcessCore(IList<DataPoint> data)
+        private IEnumerable<DataPoint> ProcessCoreImpl(IList<DataPoint> data)
         {
             if (data.Count < 2)
             {

--- a/source/gfoidl.DataCompression/Compression/NoCompression.cs
+++ b/source/gfoidl.DataCompression/Compression/NoCompression.cs
@@ -10,8 +10,9 @@ namespace gfoidl.DataCompression
         /// <summary>
         /// Implementation of the compression / filtering.
         /// </summary>
+        /// <typeparam name="TList">The type of the enumeration / list.</typeparam>
         /// <param name="data">Input data</param>
         /// <returns>The compressed / filtered data.</returns>
-        protected override IEnumerable<DataPoint> ProcessCore(IEnumerable<DataPoint> data) => data;
+        protected override IEnumerable<DataPoint> ProcessCore<TList>(in TList data) => data;
     }
 }

--- a/source/gfoidl.DataCompression/Compression/SwingingDoorCompression.cs
+++ b/source/gfoidl.DataCompression/Compression/SwingingDoorCompression.cs
@@ -78,14 +78,14 @@ namespace gfoidl.DataCompression
         /// </summary>
         /// <param name="data">Input data</param>
         /// <returns>The compressed / filtered data.</returns>
-        protected override IEnumerable<DataPoint> ProcessCore(IEnumerable<DataPoint> data)
+        protected override IEnumerable<DataPoint> ProcessCore<TList>(in TList data)
         {
-            if (data is IList<DataPoint> list) return this.ProcessCore(list);
+            if (data is IList<DataPoint> list) return this.ProcessCoreImpl(list);
 
-            return this.ProcessCore(data.GetEnumerator());
+            return this.ProcessCoreImpl(data.GetEnumerator());
         }
         //---------------------------------------------------------------------
-        private IEnumerable<DataPoint> ProcessCore(IEnumerator<DataPoint> dataEnumerator)
+        private IEnumerable<DataPoint> ProcessCoreImpl(IEnumerator<DataPoint> dataEnumerator)
         {
             if (!dataEnumerator.MoveNext()) yield break;
 
@@ -127,7 +127,7 @@ namespace gfoidl.DataCompression
                 yield return incoming;
         }
         //---------------------------------------------------------------------
-        private IEnumerable<DataPoint> ProcessCore(IList<DataPoint> data)
+        private IEnumerable<DataPoint> ProcessCoreImpl(IList<DataPoint> data)
         {
             if (data.Count < 2)
             {

--- a/source/gfoidl.DataCompression/ICompression.cs
+++ b/source/gfoidl.DataCompression/ICompression.cs
@@ -10,8 +10,9 @@ namespace gfoidl.DataCompression
         /// <summary>
         /// Performs the compression / filtering of the input data.
         /// </summary>
+        /// <typeparam name="TList">The type of the enumeration / list.</typeparam>
         /// <param name="data">Input data</param>
         /// <returns>The compressed / filtered data.</returns>
-        IEnumerable<DataPoint> Process(IEnumerable<DataPoint> data);
+        IEnumerable<DataPoint> Process<TList>(in TList data) where TList : IEnumerable<DataPoint>;
     }
 }

--- a/source/gfoidl.DataCompression/ThrowHelper.cs
+++ b/source/gfoidl.DataCompression/ThrowHelper.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace gfoidl.DataCompression
+{
+    internal static class ThrowHelper
+    {
+        public static void ThrowArgumentNull(string argName) => throw new ArgumentNullException(argName);
+    }
+}


### PR DESCRIPTION
Compression uses generics, thus allowing better JIT codegen when structs are given as types.

Break up from https://github.com/gfoidl/DataCompression/pull/6