### PR TITLE
DataPointIterator MoveNext checks if used as enumerator

### DIFF
--- a/source/gfoidl.DataCompression/Compression/DeadBandCompression.cs
+++ b/source/gfoidl.DataCompression/Compression/DeadBandCompression.cs
@@ -202,8 +202,11 @@ namespace gfoidl.DataCompression
                         _state   = 1;
                         this.UpdatePoints(_incoming, ref _snapShot);
                         return true;
+                    case InitialState:
+                        ThrowHelper.ThrowInvalidOperation(ThrowHelper.Reason.CallGetEnumeratorBeforeMoveNext);
+                        return false;
                     case DisposedState:
-                        ThrowHelper.ThrowIfDisposed(nameof(DataPointIterator));
+                        ThrowHelper.ThrowIfDisposed(ThrowHelper.Argument.iterator);
                         return false;
                 }
             }
@@ -376,8 +379,11 @@ namespace gfoidl.DataCompression
                         this.UpdatePoints(_incomingIndex, _current, ref _snapShotIndex);
                         _incomingIndex++;
                         return true;
+                    case InitialState:
+                        ThrowHelper.ThrowInvalidOperation(ThrowHelper.Reason.CallGetEnumeratorBeforeMoveNext);
+                        return false;
                     case DisposedState:
-                        ThrowHelper.ThrowIfDisposed(nameof(DataPointIterator));
+                        ThrowHelper.ThrowIfDisposed(ThrowHelper.Argument.iterator);
                         return false;
                 }
             }

--- a/source/gfoidl.DataCompression/Compression/NoCompression.cs
+++ b/source/gfoidl.DataCompression/Compression/NoCompression.cs
@@ -31,6 +31,9 @@ namespace gfoidl.DataCompression
             //-----------------------------------------------------------------
             public override bool MoveNext()
             {
+                if (_state == InitialState)
+                    ThrowHelper.ThrowInvalidOperation(ThrowHelper.Reason.CallGetEnumeratorBeforeMoveNext);
+
                 if (_enumerator.MoveNext())
                 {
                     _current = _enumerator.Current;

--- a/source/gfoidl.DataCompression/Compression/SwingingDoorCompression.cs
+++ b/source/gfoidl.DataCompression/Compression/SwingingDoorCompression.cs
@@ -257,8 +257,11 @@ namespace gfoidl.DataCompression
                         _state   = 1;
                         this.OpenNewDoor(_incoming);
                         return true;
+                    case InitialState:
+                        ThrowHelper.ThrowInvalidOperation(ThrowHelper.Reason.CallGetEnumeratorBeforeMoveNext);
+                        return false;
                     case DisposedState:
-                        ThrowHelper.ThrowIfDisposed(nameof(DataPointIterator));
+                        ThrowHelper.ThrowIfDisposed(ThrowHelper.Argument.iterator);
                         return false;
                 }
             }
@@ -443,6 +446,12 @@ namespace gfoidl.DataCompression
                         this.OpenNewDoor(incomingIndex, _incoming);
                         _incomingIndex = incomingIndex + 1;
                         return true;
+                    case InitialState:
+                        ThrowHelper.ThrowInvalidOperation(ThrowHelper.Reason.CallGetEnumeratorBeforeMoveNext);
+                        return false;
+                    case DisposedState:
+                        ThrowHelper.ThrowIfDisposed(ThrowHelper.Argument.iterator);
+                        return false;
                 }
             }
             //---------------------------------------------------------------------

--- a/source/gfoidl.DataCompression/Strings.Designer.cs
+++ b/source/gfoidl.DataCompression/Strings.Designer.cs
@@ -61,6 +61,18 @@ namespace gfoidl.DataCompression {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to You have called &apos;MoveNext&apos; on the instance of &apos;DataPointIterator&apos; without getting the enumerator first. To get the enumerator call &apos;GetEnumerator&apos; on the &apos;DataPointIterator&apos; and use this instance.
+        ///
+        ///&apos;DataPointIterator&apos; is an enumerable and iterator in one. This saves an object on the heap, hence it is a performance optimization.
+        ///When the &apos;DataPointIterator&apos; as enumerable is &quot;fresh&quot;, i.e. its state is as initialized, a call to &apos;GetEnumerator&apos; will just return the same object. Only when the (internal) state [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string GetEnumerator_must_be_called_first {
+            get {
+                return ResourceManager.GetString("GetEnumerator_must_be_called_first", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Datapoints a and b must not be equal for calculation of the gradient.
         /// </summary>
         internal static string Gradient_A_eq_B {

--- a/source/gfoidl.DataCompression/Strings.resx
+++ b/source/gfoidl.DataCompression/Strings.resx
@@ -121,7 +121,9 @@
     <value>You have called 'MoveNext' on the instance of 'DataPointIterator' without getting the enumerator first. To get the enumerator call 'GetEnumerator' on the 'DataPointIterator' and use this instance.
 
 'DataPointIterator' is an enumerable and iterator in one. This saves an object on the heap, hence it is a performance optimization.
-When the 'DataPointIterator' as enumerable is "fresh", i.e. its state is as initialized, a call to 'GetEnumerator' will just return the same object. Only when the (internal) state changed, a clone (hence a new object) will be returned.</value>
+When the 'DataPointIterator' as enumerable is "fresh", i.e. its state is as initialized, a call to 'GetEnumerator' will just return the same object. Only when the (internal) state changed, a clone (hence a new object) will be returned.
+
+So in order to set the (internal) state for enumerating, a call to `GetEnumerator` is needed. This has the logic to return this or create a clone based on the current state.</value>
   </data>
   <data name="Gradient_A_eq_B" xml:space="preserve">
     <value>Datapoints a and b must not be equal for calculation of the gradient</value>

--- a/source/gfoidl.DataCompression/Strings.resx
+++ b/source/gfoidl.DataCompression/Strings.resx
@@ -117,6 +117,12 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="GetEnumerator_must_be_called_first" xml:space="preserve">
+    <value>You have called 'MoveNext' on the instance of 'DataPointIterator' without getting the enumerator first. To get the enumerator call 'GetEnumerator' on the 'DataPointIterator' and use this instance.
+
+'DataPointIterator' is an enumerable and iterator in one. This saves an object on the heap, hence it is a performance optimization.
+When the 'DataPointIterator' as enumerable is "fresh", i.e. its state is as initialized, a call to 'GetEnumerator' will just return the same object. Only when the (internal) state changed, a clone (hence a new object) will be returned.</value>
+  </data>
   <data name="Gradient_A_eq_B" xml:space="preserve">
     <value>Datapoints a and b must not be equal for calculation of the gradient</value>
   </data>

--- a/source/gfoidl.DataCompression/ThrowHelper.cs
+++ b/source/gfoidl.DataCompression/ThrowHelper.cs
@@ -7,27 +7,28 @@ namespace gfoidl.DataCompression
         public static void ThrowArgumentNull(Argument argument)    => throw new ArgumentNullException(argument.ToString());
         public static void ThrowArgumentOutOfRange(string argName) => throw new ArgumentOutOfRangeException(argName);
         public static void ThrowNotSupported()                     => throw new NotSupportedException();
-        public static void ThrowIfDisposed(string objName)         => throw new ObjectDisposedException(objName);
+        public static void ThrowIfDisposed(Argument argument)      => throw new ObjectDisposedException(argument.ToString());
         public static void ThrowInvalidOperation(Reason reason)    => throw new InvalidOperationException(GetReasonString(reason));
         //---------------------------------------------------------------------
         public enum Argument
         {
-            data
+            data,
+            iterator
         }
         //---------------------------------------------------------------------
         public enum Reason
         {
-            ShouldNotHappen
+            ShouldNotHappen,
+            CallGetEnumeratorBeforeMoveNext
         }
         //---------------------------------------------------------------------
         private static string GetReasonString(Reason reason)
         {
             switch (reason)
             {
-                case Reason.ShouldNotHappen:
-                    return Strings.Should_not_happen;
-                default:
-                    return string.Empty;
+                case Reason.ShouldNotHappen:                 return Strings.Should_not_happen;
+                case Reason.CallGetEnumeratorBeforeMoveNext: return Strings.GetEnumerator_must_be_called_first;
+                default:                                     return string.Empty;
             }
         }
     }

--- a/tests/gfoidl.DataCompression.Tests/Compression/DeadBandCompressionTests/MoveNext.cs
+++ b/tests/gfoidl.DataCompression.Tests/Compression/DeadBandCompressionTests/MoveNext.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+
+namespace gfoidl.DataCompression.Tests.Compression.DeadBandCompressionTests
+{
+    [TestFixture]
+    public class MoveNext
+    {
+        private static readonly DataPointSerializer _ser = new DataPointSerializer();
+        //---------------------------------------------------------------------
+        [Test]
+        public void MoveNext_without_GetEnumerator___throws_InvalidOperation()
+        {
+            var sut  = new DeadBandCompression(1);
+            var data = RawDataForTrend();
+
+            var iterator = sut.Process(data);
+
+            Assert.Throws<InvalidOperationException>(() => iterator.MoveNext());
+        }
+        //---------------------------------------------------------------------
+        [Test]
+        public void Indexed_MoveNext_without_GetEnumerator___throws_InvalidOperation()
+        {
+            var sut  = new DeadBandCompression(1);
+            var data = RawDataForTrend().ToArray();
+
+            var iterator = sut.Process(data);
+
+            Assert.Throws<InvalidOperationException>(() => iterator.MoveNext());
+        }
+        //---------------------------------------------------------------------
+        private static IEnumerable<DataPoint> RawDataForTrend() => _ser.Read("../../../../../doc/data/dead-band/trend_raw.csv");
+    }
+}

--- a/tests/gfoidl.DataCompression.Tests/Compression/NoCompressionTests/MoveNext.cs
+++ b/tests/gfoidl.DataCompression.Tests/Compression/NoCompressionTests/MoveNext.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace gfoidl.DataCompression.Tests.Compression.NoCompressionTests
+{
+    [TestFixture]
+    public class MoveNext
+    {
+        private static readonly DataPointSerializer _ser = new DataPointSerializer();
+        //---------------------------------------------------------------------
+        [Test]
+        public void MoveNext_without_GetEnumerator___throws_InvalidOperation()
+        {
+            var sut  = new NoCompression();
+            var data = RawDataForTrend();
+
+            var iterator = sut.Process(data);
+
+            Assert.Throws<InvalidOperationException>(() => iterator.MoveNext());
+        }
+        //---------------------------------------------------------------------
+        private static IEnumerable<DataPoint> RawDataForTrend() => _ser.Read("../../../../../doc/data/dead-band/trend_raw.csv");
+    }
+}

--- a/tests/gfoidl.DataCompression.Tests/Compression/SwingingDoorCompressionTests/MoveNext.cs
+++ b/tests/gfoidl.DataCompression.Tests/Compression/SwingingDoorCompressionTests/MoveNext.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+
+namespace gfoidl.DataCompression.Tests.Compression.SwingingDoorCompressionTests
+{
+    [TestFixture]
+    public class MoveNext
+    {
+        private static readonly DataPointSerializer _ser = new DataPointSerializer();
+        //---------------------------------------------------------------------
+        [Test]
+        public void Enumerable_MoveNext_without_GetEnumerator___throws_InvalidOperation()
+        {
+            var sut  = new SwingingDoorCompression(1);
+            var data = RawDataForTrend();
+
+            var iterator = sut.Process(data);
+
+            Assert.Throws<InvalidOperationException>(() => iterator.MoveNext());
+        }
+        //---------------------------------------------------------------------
+        [Test]
+        public void Indexed_MoveNext_without_GetEnumerator___throws_InvalidOperation()
+        {
+            var sut  = new SwingingDoorCompression(1);
+            var data = RawDataForTrend().ToArray();
+
+            var iterator = sut.Process(data);
+
+            Assert.Throws<InvalidOperationException>(() => iterator.MoveNext());
+        }
+        //---------------------------------------------------------------------
+        private static IEnumerable<DataPoint> RawDataForTrend() => _ser.Read("../../../../../doc/data/dead-band/trend_raw.csv");
+    }
+}


### PR DESCRIPTION
DataPointIterator checks its state when `MoveNext` is called and throws when not used as enumerator

Fixes https://github.com/gfoidl/DataCompression/issues/22