### PR TITLE
Improved codegen (register use) for Gradient

### DIFF
--- a/source/gfoidl.DataCompression/DataPoint.cs
+++ b/source/gfoidl.DataCompression/DataPoint.cs
@@ -87,9 +87,12 @@ namespace gfoidl.DataCompression
         [DebuggerStepThrough]
         public double Gradient(in DataPoint b, bool return0OnEquality = true)
         {
-            if (this.X == b.X) return this.GradientEquality(b, return0OnEquality);
+            double deltaY = b.Y - this.Y;
+            double deltaX = b.X - this.X;
 
-            return (b.Y - this.Y) / (b.X - this.X);
+            if (deltaX == 0d) return this.GradientEquality(b, return0OnEquality);
+
+            return deltaY / deltaX;
         }
         //---------------------------------------------------------------------
         [DebuggerStepThrough]

--- a/source/gfoidl.DataCompression/DataPoint.cs
+++ b/source/gfoidl.DataCompression/DataPoint.cs
@@ -87,20 +87,23 @@ namespace gfoidl.DataCompression
         [DebuggerStepThrough]
         public double Gradient(in DataPoint b, bool return0OnEquality = true)
         {
-            double deltaY = b.Y - this.Y;
-            double deltaX = b.X - this.X;
+            double delta_y = b.Y - this.Y;
+            double delta_x = b.X - this.X;
 
-            if (deltaX == 0d) return this.GradientEquality(b, return0OnEquality);
+            if (delta_x == 0d) return this.GradientEquality(b, return0OnEquality);
 
-            return deltaY / deltaX;
+            return delta_y / delta_x;
         }
         //---------------------------------------------------------------------
         [DebuggerStepThrough]
         internal double Gradient(in DataPoint b, double deltaY, bool return0OnEquality = true)
         {
-            if (this.X == b.X) return this.GradientEquality(b, return0OnEquality);
+            double delta_y = b.Y + deltaY - this.Y;
+            double delta_x = b.X - this.X;
 
-            return (b.Y + deltaY - this.Y) / (b.X - this.X);
+            if (delta_x == 0d) return this.GradientEquality(b, return0OnEquality);
+
+            return delta_y / delta_x;
         }
         //---------------------------------------------------------------------
         // Uncommon code-path

--- a/source/gfoidl.DataCompression/DataPoint.cs
+++ b/source/gfoidl.DataCompression/DataPoint.cs
@@ -138,9 +138,12 @@ namespace gfoidl.DataCompression
         /// </remarks>
         public double CalculatePoint(double gradient, double x)
         {
-            if (this.X == x) return this.Y;
+            double y = this.Y;
+            x       -= this.X;
 
-            return this.Y + gradient * (x - this.X);
+            if (x == 0) return y;
+
+            return y + gradient * x;
         }
         //---------------------------------------------------------------------
         /// <summary>


### PR DESCRIPTION
Fixes https://github.com/gfoidl/DataCompression/issues/31

Codegen for this version is
```asm
G_M38338_IG01:
       55                   push     rbp
       C5F877               vzeroupper
       488BEC               mov      rbp, rsp

G_M38338_IG02:
       C4E17B104208         vmovsd   xmm0, qword ptr [rdx+8]    ; xmm0 = b.Y
       C4E17B5C4608         vsubsd   xmm0, qword ptr [rsi+8]    ; xmm0 = xmm0 - this.Y
       C4E17B100A           vmovsd   xmm1, qword ptr [rdx]      ; xmm1 = b.X
       C4E1735C0E           vsubsd   xmm1, qword ptr [rsi]      ; xmm1 = xmm1 - this.X
       C4E16857D2           vxorps   xmm2, xmm2
       C4E1792ECA           vucomisd xmm1, xmm2
       7A14                 jpe      SHORT G_M38338_IG03
       7512                 jne      SHORT G_M38338_IG03
       488BFE               mov      rdi, rsi
       488BF2               mov      rsi, rdx
       BA01000000           mov      edx, 1
       E815FAFFFF           call     ConsoleApp3.DataPoint:GradientEquality(byref,bool):double:this
       EB05                 jmp      SHORT G_M38338_IG04

G_M38338_IG03:
       C4E17B5EC1           vdivsd   xmm0, xmm1                 ; xmm0 = xmm1 / xmm0

G_M38338_IG04:
       5D                   pop      rbp
       C3                   ret
```
So really cool 😄 

clang, g++ don't produce better code. Great RyuJIT!