### PR TITLE
ThrowHelper used in more places and enums instead of strings

### DIFF
--- a/source/gfoidl.DataCompression/Compression.cs
+++ b/source/gfoidl.DataCompression/Compression.cs
@@ -17,7 +17,7 @@ namespace gfoidl.DataCompression
         /// </exception>
         public DataPointIterator Process(IEnumerable<DataPoint> data)
         {
-            if (data == null) ThrowHelper.ThrowArgumentNull(ThrowHelper.Argument.data);
+            if (data == null) ThrowHelper.ThrowArgumentNull(ThrowHelper.ExceptionArgument.data);
 
             return this.ProcessCore(data);
         }

--- a/source/gfoidl.DataCompression/Compression/DeadBandCompression.cs
+++ b/source/gfoidl.DataCompression/Compression/DeadBandCompression.cs
@@ -203,10 +203,10 @@ namespace gfoidl.DataCompression
                         this.UpdatePoints(_incoming, ref _snapShot);
                         return true;
                     case InitialState:
-                        ThrowHelper.ThrowInvalidOperation(ThrowHelper.Reason.CallGetEnumeratorBeforeMoveNext);
+                        ThrowHelper.ThrowInvalidOperation(ThrowHelper.ExceptionResource.GetEnumerator_must_be_called_first);
                         return false;
                     case DisposedState:
-                        ThrowHelper.ThrowIfDisposed(ThrowHelper.Argument.iterator);
+                        ThrowHelper.ThrowIfDisposed(ThrowHelper.ExceptionArgument.iterator);
                         return false;
                 }
             }
@@ -380,10 +380,10 @@ namespace gfoidl.DataCompression
                         _incomingIndex++;
                         return true;
                     case InitialState:
-                        ThrowHelper.ThrowInvalidOperation(ThrowHelper.Reason.CallGetEnumeratorBeforeMoveNext);
+                        ThrowHelper.ThrowInvalidOperation(ThrowHelper.ExceptionResource.GetEnumerator_must_be_called_first);
                         return false;
                     case DisposedState:
-                        ThrowHelper.ThrowIfDisposed(ThrowHelper.Argument.iterator);
+                        ThrowHelper.ThrowIfDisposed(ThrowHelper.ExceptionArgument.iterator);
                         return false;
                 }
             }
@@ -463,7 +463,7 @@ namespace gfoidl.DataCompression
                 int lastArchived = _lastArchivedIndex;
 
                 if ((uint)incomingIndex >= (uint)source.Count || (uint)lastArchived >= (uint)source.Count)
-                    ThrowHelper.ThrowInvalidOperation(ThrowHelper.Reason.ShouldNotHappen);
+                    ThrowHelper.ThrowInvalidOperation(ThrowHelper.ExceptionResource.Should_not_happen);
 
                 double lastArchived_x = source[lastArchived].X;
                 DataPoint incoming    = source[incomingIndex];

--- a/source/gfoidl.DataCompression/Compression/NoCompression.cs
+++ b/source/gfoidl.DataCompression/Compression/NoCompression.cs
@@ -32,7 +32,7 @@ namespace gfoidl.DataCompression
             public override bool MoveNext()
             {
                 if (_state == InitialState)
-                    ThrowHelper.ThrowInvalidOperation(ThrowHelper.Reason.CallGetEnumeratorBeforeMoveNext);
+                    ThrowHelper.ThrowInvalidOperation(ThrowHelper.ExceptionResource.GetEnumerator_must_be_called_first);
 
                 if (_enumerator.MoveNext())
                 {

--- a/source/gfoidl.DataCompression/Compression/SwingingDoorCompression.cs
+++ b/source/gfoidl.DataCompression/Compression/SwingingDoorCompression.cs
@@ -258,10 +258,10 @@ namespace gfoidl.DataCompression
                         this.OpenNewDoor(_incoming);
                         return true;
                     case InitialState:
-                        ThrowHelper.ThrowInvalidOperation(ThrowHelper.Reason.CallGetEnumeratorBeforeMoveNext);
+                        ThrowHelper.ThrowInvalidOperation(ThrowHelper.ExceptionResource.GetEnumerator_must_be_called_first);
                         return false;
                     case DisposedState:
-                        ThrowHelper.ThrowIfDisposed(ThrowHelper.Argument.iterator);
+                        ThrowHelper.ThrowIfDisposed(ThrowHelper.ExceptionArgument.iterator);
                         return false;
                 }
             }
@@ -447,10 +447,10 @@ namespace gfoidl.DataCompression
                         _incomingIndex = incomingIndex + 1;
                         return true;
                     case InitialState:
-                        ThrowHelper.ThrowInvalidOperation(ThrowHelper.Reason.CallGetEnumeratorBeforeMoveNext);
+                        ThrowHelper.ThrowInvalidOperation(ThrowHelper.ExceptionResource.GetEnumerator_must_be_called_first);
                         return false;
                     case DisposedState:
-                        ThrowHelper.ThrowIfDisposed(ThrowHelper.Argument.iterator);
+                        ThrowHelper.ThrowIfDisposed(ThrowHelper.ExceptionArgument.iterator);
                         return false;
                 }
             }

--- a/source/gfoidl.DataCompression/DataPoint.cs
+++ b/source/gfoidl.DataCompression/DataPoint.cs
@@ -122,7 +122,10 @@ namespace gfoidl.DataCompression
                 }
             }
             else
-                throw new ArgumentException(Strings.Gradient_A_eq_B, nameof(b));
+            {
+                ThrowHelper.ThrowArgument(ThrowHelper.ExceptionResource.Gradient_A_eq_B);
+                return 0;
+            }
         }
 
         //---------------------------------------------------------------------

--- a/source/gfoidl.DataCompression/ExtensionMethods.cs
+++ b/source/gfoidl.DataCompression/ExtensionMethods.cs
@@ -18,7 +18,7 @@ namespace gfoidl.DataCompression
         /// </exception>
         public static DataPointIterator NoCompression(this IEnumerable<DataPoint> data)
         {
-            if (data == null) ThrowHelper.ThrowArgumentNull(ThrowHelper.Argument.data);
+            if (data == null) ThrowHelper.ThrowArgumentNull(ThrowHelper.ExceptionArgument.data);
 
             var compression = new NoCompression();
             return compression.Process(data);
@@ -38,7 +38,7 @@ namespace gfoidl.DataCompression
         /// </exception>
         public static DataPointIterator DeadBandCompression(this IEnumerable<DataPoint> data, double instrumentPrecision, double? maxDeltaX = null)
         {
-            if (data == null) ThrowHelper.ThrowArgumentNull(ThrowHelper.Argument.data);
+            if (data == null) ThrowHelper.ThrowArgumentNull(ThrowHelper.ExceptionArgument.data);
 
             var compression = new DeadBandCompression(instrumentPrecision, maxDeltaX);
             return compression.Process(data);
@@ -56,7 +56,7 @@ namespace gfoidl.DataCompression
         /// </exception>
         public static DataPointIterator DeadBandCompression(this IEnumerable<DataPoint> data, double instrumentPrecision, TimeSpan maxTime)
         {
-            if (data == null) ThrowHelper.ThrowArgumentNull(ThrowHelper.Argument.data);
+            if (data == null) ThrowHelper.ThrowArgumentNull(ThrowHelper.ExceptionArgument.data);
 
             var compression = new DeadBandCompression(instrumentPrecision, maxTime);
             return compression.Process(data);
@@ -83,7 +83,7 @@ namespace gfoidl.DataCompression
         /// </exception>
         public static DataPointIterator SwingingDoorCompression(this IEnumerable<DataPoint> data, double compressionDeviation, double? maxDeltaX = null, double? minDeltaX = null)
         {
-            if (data == null) ThrowHelper.ThrowArgumentNull(ThrowHelper.Argument.data);
+            if (data == null) ThrowHelper.ThrowArgumentNull(ThrowHelper.ExceptionArgument.data);
 
             var compression = new SwingingDoorCompression(compressionDeviation, maxDeltaX, minDeltaX);
             return compression.Process(data);
@@ -105,7 +105,7 @@ namespace gfoidl.DataCompression
         /// </exception>
         public static DataPointIterator SwingingDoorCompression(this IEnumerable<DataPoint> data, double compressionDeviation, TimeSpan maxTime, TimeSpan? minTime)
         {
-            if (data == null) ThrowHelper.ThrowArgumentNull(ThrowHelper.Argument.data);
+            if (data == null) ThrowHelper.ThrowArgumentNull(ThrowHelper.ExceptionArgument.data);
 
             var compression = new SwingingDoorCompression(compressionDeviation, maxTime, minTime);
             return compression.Process(data);

--- a/source/gfoidl.DataCompression/ThrowHelper.cs
+++ b/source/gfoidl.DataCompression/ThrowHelper.cs
@@ -1,35 +1,49 @@
 ﻿using System;
+using System.Diagnostics;
 
 namespace gfoidl.DataCompression
 {
     internal static class ThrowHelper
     {
-        public static void ThrowArgumentNull(Argument argument)    => throw new ArgumentNullException(argument.ToString());
-        public static void ThrowArgumentOutOfRange(string argName) => throw new ArgumentOutOfRangeException(argName);
-        public static void ThrowNotSupported()                     => throw new NotSupportedException();
-        public static void ThrowIfDisposed(Argument argument)      => throw new ObjectDisposedException(argument.ToString());
-        public static void ThrowInvalidOperation(Reason reason)    => throw new InvalidOperationException(GetReasonString(reason));
+        public static void ThrowArgumentNull(ExceptionArgument argument)       => throw new ArgumentNullException(GetArgumentName(argument));
+        public static void ThrowArgumentOutOfRange(ExceptionArgument argument) => throw new ArgumentOutOfRangeException(GetArgumentName(argument));
+        public static void ThrowArgument(ExceptionResource resource)           => throw new ArgumentException(GetResourceText(resource));
+        public static void ThrowNotSupported()                                 => throw new NotSupportedException();
+        public static void ThrowIfDisposed(ExceptionArgument argument)         => throw new ObjectDisposedException(argument.ToString());
+        public static void ThrowInvalidOperation(ExceptionResource resource)   => throw new InvalidOperationException(GetResourceText(resource));
         //---------------------------------------------------------------------
-        public enum Argument
+        private static string GetArgumentName(ExceptionArgument argument)
+        {
+            Debug.Assert(
+                Enum.IsDefined(typeof(ExceptionArgument), argument),
+                "The enum value is not defined, please check the 'ExceptionArgument' enum.");
+
+            return argument.ToString();
+        }
+        //---------------------------------------------------------------------
+        private static string GetResourceName(ExceptionResource resource)
+        {
+            Debug.Assert(
+                Enum.IsDefined(typeof(ExceptionResource), resource),
+                "The enum value is not defined, please check the 'ExceptionResource' enum.");
+
+            return resource.ToString();
+        }
+        //---------------------------------------------------------------------
+        private static string GetResourceText(ExceptionResource resource)
+            => Strings.ResourceManager.GetString(GetResourceName(resource), Strings.Culture);
+        //---------------------------------------------------------------------
+        public enum ExceptionArgument
         {
             data,
             iterator
         }
         //---------------------------------------------------------------------
-        public enum Reason
+        public enum ExceptionResource
         {
-            ShouldNotHappen,
-            CallGetEnumeratorBeforeMoveNext
-        }
-        //---------------------------------------------------------------------
-        private static string GetReasonString(Reason reason)
-        {
-            switch (reason)
-            {
-                case Reason.ShouldNotHappen:                 return Strings.Should_not_happen;
-                case Reason.CallGetEnumeratorBeforeMoveNext: return Strings.GetEnumerator_must_be_called_first;
-                default:                                     return string.Empty;
-            }
+            GetEnumerator_must_be_called_first,
+            Gradient_A_eq_B,
+            Should_not_happen
         }
     }
 }


### PR DESCRIPTION
For reason see comment in https://referencesource.microsoft.com/#mscorlib/system/throwhelper.cs

Extension of https://github.com/gfoidl/DataCompression/pull/29