### PR TITLE
Reduced allocations in async iteration

### DIFF
--- a/demos/gfoidl.DataCompression.Demos.Async/Program.cs
+++ b/demos/gfoidl.DataCompression.Demos.Async/Program.cs
@@ -12,7 +12,8 @@ namespace gfoidl.DataCompression.Demos.Async
         {
             var cts                            = new CancellationTokenSource();
             IAsyncEnumerable<DataPoint> source = Source(cts.Token);
-            DataPointIterator filtered         = source.DeadBandCompressionAsync(0.01, ct: cts.Token);
+            //DataPointIterator filtered         = source.DeadBandCompressionAsync(0.01, ct: cts.Token);
+            DataPointIterator filtered         = source.SwingingDoorCompressionAsync(0.01, ct: cts.Token);
             ValueTask<double> sinkTask         = Sink(filtered, cts.Token);
 
             Console.WriteLine("any key to stop...");

--- a/demos/gfoidl.DataCompression.Demos.Async/Program.cs
+++ b/demos/gfoidl.DataCompression.Demos.Async/Program.cs
@@ -12,8 +12,8 @@ namespace gfoidl.DataCompression.Demos.Async
         {
             var cts                            = new CancellationTokenSource();
             IAsyncEnumerable<DataPoint> source = Source(cts.Token);
-            //DataPointIterator filtered         = source.DeadBandCompressionAsync(0.01, ct: cts.Token);
-            DataPointIterator filtered         = source.SwingingDoorCompressionAsync(0.01, ct: cts.Token);
+            //DataPointIterator filtered         = source.DeadBandCompressionAsync(0.01);
+            DataPointIterator filtered         = source.SwingingDoorCompressionAsync(0.01);
             ValueTask<double> sinkTask         = Sink(filtered, cts.Token);
 
             Console.WriteLine("any key to stop...");

--- a/demos/gfoidl.DataCompression.Demos.Async/Program.cs
+++ b/demos/gfoidl.DataCompression.Demos.Async/Program.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace gfoidl.DataCompression.Demos.Async
+{
+    class Program
+    {
+        static async Task Main(string[] args)
+        {
+            var cts                            = new CancellationTokenSource();
+            IAsyncEnumerable<DataPoint> source = Source(cts.Token);
+            DataPointIterator filtered         = source.DeadBandCompressionAsync(0.01, ct: cts.Token);
+            ValueTask<double> sinkTask         = Sink(filtered, cts.Token);
+
+            Console.WriteLine("any key to stop...");
+            Console.ReadKey();
+
+            cts.Cancel();
+            double sum = default;
+            try
+            {
+                sum = await sinkTask;
+            }
+            catch (OperationCanceledException) { }
+
+            Console.WriteLine($"sum: {sum}");
+        }
+        //---------------------------------------------------------------------
+        private static async IAsyncEnumerable<DataPoint> Source([EnumeratorCancellation] CancellationToken ct = default)
+        {
+            int i   = 0;
+            var rnd = new Random(42);
+
+            while (!ct.IsCancellationRequested)
+            {
+                await Task.Yield();
+                double x = i++;
+                double y = rnd.NextDouble();
+
+                yield return new DataPoint(x, y);
+            }
+        }
+        //---------------------------------------------------------------------
+        private static async ValueTask<double> Sink(DataPointIterator data, CancellationToken ct = default)
+        {
+            double sum = 0;
+            uint count = 0;
+
+            await foreach (DataPoint dp in data.WithCancellation(ct))
+            {
+                sum += dp.Y;
+
+                if (count % (1 << 15) == 0)
+                {
+                    Console.WriteLine($"count: {count}, sum: {sum}");
+                }
+                count++;
+            }
+
+            return sum;
+        }
+    }
+}

--- a/demos/gfoidl.DataCompression.Demos.Async/gfoidl.DataCompression.Demos.Async.csproj
+++ b/demos/gfoidl.DataCompression.Demos.Async/gfoidl.DataCompression.Demos.Async.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>$(StandardTfm)</TargetFramework>
+    </PropertyGroup>
+
+</Project>

--- a/gfoidl.DataCompression.sln
+++ b/gfoidl.DataCompression.sln
@@ -100,6 +100,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "perf", "perf", "{CEFBCCE8-6
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "gfoidl.DataCompression.Benchmarks", "perf\gfoidl.DataCompression.Benchmarks\gfoidl.DataCompression.Benchmarks.csproj", "{81D55029-F85F-4624-BAA1-7128A6FA1A66}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "gfoidl.DataCompression.Demos.Async", "demos\gfoidl.DataCompression.Demos.Async\gfoidl.DataCompression.Demos.Async.csproj", "{9C0564C7-5902-40C1-9883-887BF7AC2187}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -138,6 +140,10 @@ Global
 		{81D55029-F85F-4624-BAA1-7128A6FA1A66}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{81D55029-F85F-4624-BAA1-7128A6FA1A66}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{81D55029-F85F-4624-BAA1-7128A6FA1A66}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9C0564C7-5902-40C1-9883-887BF7AC2187}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9C0564C7-5902-40C1-9883-887BF7AC2187}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9C0564C7-5902-40C1-9883-887BF7AC2187}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9C0564C7-5902-40C1-9883-887BF7AC2187}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -156,6 +162,7 @@ Global
 		{76F6F753-4F3F-4AC3-9DB0-324176F9A143} = {26C3FC5E-B8F2-4B7E-B264-7EC29772DC7C}
 		{4461519B-5A2E-4B38-A93B-B561244C05C8} = {5EC3A886-352D-490B-90F0-F0EEA56C959F}
 		{81D55029-F85F-4624-BAA1-7128A6FA1A66} = {CEFBCCE8-6F5E-483A-97D2-58907F7BCE24}
+		{9C0564C7-5902-40C1-9883-887BF7AC2187} = {26C3FC5E-B8F2-4B7E-B264-7EC29772DC7C}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {BB4A29EA-001D-4E57-BBF5-C442F27797AE}

--- a/source/gfoidl.DataCompression/Compression.cs
+++ b/source/gfoidl.DataCompression/Compression.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Threading;
 
 namespace gfoidl.DataCompression
 {
@@ -75,13 +74,12 @@ namespace gfoidl.DataCompression
         /// Performs the compression / filtering of the input data.
         /// </summary>
         /// <param name="data">Input data</param>
-        /// <param name="ct">The token for cancellation.</param>
         /// <returns>The compressed / filtered data.</returns>
-        public DataPointIterator ProcessAsync(IAsyncEnumerable<DataPoint>? data, CancellationToken ct = default)
+        public DataPointIterator ProcessAsync(IAsyncEnumerable<DataPoint>? data)
         {
             if (data is null) ThrowHelper.ThrowArgumentNull(ThrowHelper.ExceptionArgument.data);
 
-            return this.ProcessAsyncCore(data, ct);
+            return this.ProcessAsyncCore(data);
         }
 #endif
         //---------------------------------------------------------------------
@@ -97,9 +95,8 @@ namespace gfoidl.DataCompression
         /// Implementation of the compression / filtering.
         /// </summary>
         /// <param name="data">Input data</param>
-        /// <param name="ct">The token for cancellation.</param>
         /// <returns>The compressed / filtered data.</returns>
-        protected abstract DataPointIterator ProcessAsyncCore(IAsyncEnumerable<DataPoint> data, CancellationToken ct);
+        protected abstract DataPointIterator ProcessAsyncCore(IAsyncEnumerable<DataPoint> data);
 #endif
     }
 }

--- a/source/gfoidl.DataCompression/Compression/DeadBandCompression/AsyncEnumerableIterator.cs
+++ b/source/gfoidl.DataCompression/Compression/DeadBandCompression/AsyncEnumerableIterator.cs
@@ -9,13 +9,11 @@ namespace gfoidl.DataCompression.Internal.DeadBand
         public AsyncEnumerableIterator(
             DeadBandCompression          deadBandCompression,
             IAsyncEnumerable<DataPoint>  source,
-            IAsyncEnumerator<DataPoint>? enumerator        = null,
             CancellationToken            cancellationToken = default)
             : base(deadBandCompression)
         {
             if (cancellationToken != default) _cancellationToken = cancellationToken;
-            _asyncSource     = source;
-            _asyncEnumerator = enumerator ?? source.GetAsyncEnumerator(_cancellationToken);
+            _asyncSource = source;
         }
         //---------------------------------------------------------------------
         public override DataPointIterator Clone() => throw new NotSupportedException();

--- a/source/gfoidl.DataCompression/Compression/DeadBandCompression/AsyncEnumerableIterator.cs
+++ b/source/gfoidl.DataCompression/Compression/DeadBandCompression/AsyncEnumerableIterator.cs
@@ -1,20 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Threading;
 
 namespace gfoidl.DataCompression.Internal.DeadBand
 {
     internal sealed class AsyncEnumerableIterator : DeadBandCompressionIterator
     {
-        public AsyncEnumerableIterator(
-            DeadBandCompression          deadBandCompression,
-            IAsyncEnumerable<DataPoint>  source,
-            CancellationToken            cancellationToken = default)
+        public AsyncEnumerableIterator(DeadBandCompression deadBandCompression, IAsyncEnumerable<DataPoint> source)
             : base(deadBandCompression)
-        {
-            if (cancellationToken != default) _cancellationToken = cancellationToken;
-            _asyncSource = source;
-        }
+            => _asyncSource = source;
         //---------------------------------------------------------------------
         public override DataPointIterator Clone() => throw new NotSupportedException();
         public override bool MoveNext()           => throw new NotSupportedException();

--- a/source/gfoidl.DataCompression/Compression/DeadBandCompression/DeadBandCompression.cs
+++ b/source/gfoidl.DataCompression/Compression/DeadBandCompression/DeadBandCompression.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Threading;
 using gfoidl.DataCompression.Internal.DeadBand;
 using gfoidl.DataCompression.Wrappers;
 
@@ -101,10 +100,9 @@ namespace gfoidl.DataCompression
         /// Implementation of the compression / filtering.
         /// </summary>
         /// <param name="data">Input data</param>
-        /// <param name="ct">The token for cancellation.</param>
         /// <returns>The compressed / filtered data.</returns>
-        protected override DataPointIterator ProcessAsyncCore(IAsyncEnumerable<DataPoint> data, CancellationToken ct)
-            => new AsyncEnumerableIterator(this, data, cancellationToken: ct);
+        protected override DataPointIterator ProcessAsyncCore(IAsyncEnumerable<DataPoint> data)
+            => new AsyncEnumerableIterator(this, data);
 #endif
     }
 }

--- a/source/gfoidl.DataCompression/Compression/DeadBandCompression/IndexedIterator.cs
+++ b/source/gfoidl.DataCompression/Compression/DeadBandCompression/IndexedIterator.cs
@@ -42,7 +42,6 @@ namespace gfoidl.DataCompression.Internal.DeadBand
         protected internal override void Init(in DataPoint incoming, ref DataPoint snapShot)                   => throw new NotSupportedException();
         //---------------------------------------------------------------------
 #if NETSTANDARD2_1
-        public override ValueTask<bool> MoveNextAsync()          => throw new NotSupportedException();
         public override ValueTask<DataPoint[]> ToArrayAsync()    => throw new NotSupportedException();
         public override ValueTask<List<DataPoint>> ToListAsync() => throw new NotSupportedException();
 #endif

--- a/source/gfoidl.DataCompression/Compression/DeadBandCompression/IndexedIterator.cs
+++ b/source/gfoidl.DataCompression/Compression/DeadBandCompression/IndexedIterator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace gfoidl.DataCompression.Internal.DeadBand
@@ -42,8 +43,8 @@ namespace gfoidl.DataCompression.Internal.DeadBand
         protected internal override void Init(in DataPoint incoming, ref DataPoint snapShot)                   => throw new NotSupportedException();
         //---------------------------------------------------------------------
 #if NETSTANDARD2_1
-        public override ValueTask<DataPoint[]> ToArrayAsync()    => throw new NotSupportedException();
-        public override ValueTask<List<DataPoint>> ToListAsync() => throw new NotSupportedException();
+        public override ValueTask<DataPoint[]> ToArrayAsync(CancellationToken ct)    => throw new NotSupportedException();
+        public override ValueTask<List<DataPoint>> ToListAsync(CancellationToken ct) => throw new NotSupportedException();
 #endif
     }
 }

--- a/source/gfoidl.DataCompression/Compression/DeadBandCompression/SequentialEnumerableIterator.cs
+++ b/source/gfoidl.DataCompression/Compression/DeadBandCompression/SequentialEnumerableIterator.cs
@@ -19,7 +19,6 @@ namespace gfoidl.DataCompression.Internal.DeadBand
         public override DataPointIterator Clone() => new SequentialEnumerableIterator(_deadBandCompression, _source, _enumerator);
         //---------------------------------------------------------------------
 #if NETSTANDARD2_1
-        public override ValueTask<bool> MoveNextAsync()          => throw new NotSupportedException();
         public override ValueTask<DataPoint[]> ToArrayAsync()    => throw new NotSupportedException();
         public override ValueTask<List<DataPoint>> ToListAsync() => throw new NotSupportedException();
 #endif

--- a/source/gfoidl.DataCompression/Compression/DeadBandCompression/SequentialEnumerableIterator.cs
+++ b/source/gfoidl.DataCompression/Compression/DeadBandCompression/SequentialEnumerableIterator.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace gfoidl.DataCompression.Internal.DeadBand
@@ -19,8 +20,8 @@ namespace gfoidl.DataCompression.Internal.DeadBand
         public override DataPointIterator Clone() => new SequentialEnumerableIterator(_deadBandCompression, _source, _enumerator);
         //---------------------------------------------------------------------
 #if NETSTANDARD2_1
-        public override ValueTask<DataPoint[]> ToArrayAsync()    => throw new NotSupportedException();
-        public override ValueTask<List<DataPoint>> ToListAsync() => throw new NotSupportedException();
+        public override ValueTask<DataPoint[]> ToArrayAsync(CancellationToken ct)    => throw new NotSupportedException();
+        public override ValueTask<List<DataPoint>> ToListAsync(CancellationToken ct) => throw new NotSupportedException();
 #endif
     }
 }

--- a/source/gfoidl.DataCompression/Compression/NoCompression/AsyncEnumerableIterator.cs
+++ b/source/gfoidl.DataCompression/Compression/NoCompression/AsyncEnumerableIterator.cs
@@ -26,7 +26,7 @@ namespace gfoidl.DataCompression.Internal.NoCompression
             }
         }
         //---------------------------------------------------------------------
-        private protected override async ValueTask BuildCollectionAsync(ICollectionBuilder<DataPoint> builder, CancellationToken cancellationToken)
+        private protected override async ValueTask BuildCollectionAsync<TBuilder>(TBuilder builder, CancellationToken cancellationToken)
         {
             await foreach (DataPoint dataPoint in _asyncSource.WithCancellation(cancellationToken).ConfigureAwait(false))
             {

--- a/source/gfoidl.DataCompression/Compression/NoCompression/AsyncEnumerableIterator.cs
+++ b/source/gfoidl.DataCompression/Compression/NoCompression/AsyncEnumerableIterator.cs
@@ -34,20 +34,6 @@ namespace gfoidl.DataCompression.Internal.NoCompression
             return default;
         }
         //---------------------------------------------------------------------
-        public override async ValueTask<DataPoint[]> ToArrayAsync()
-        {
-            ICollectionBuilder<DataPoint> arrayBuilder = new ArrayBuilder<DataPoint>(true);
-            await this.BuildCollectionAsync(arrayBuilder).ConfigureAwait(false);
-            return ((ArrayBuilder<DataPoint>)arrayBuilder).ToArray();
-        }
-        //---------------------------------------------------------------------
-        public override async ValueTask<List<DataPoint>> ToListAsync()
-        {
-            var listBuilder = new ListBuilder<DataPoint>(true);
-            await this.BuildCollectionAsync(listBuilder).ConfigureAwait(false);
-            return listBuilder.ToList();
-        }
-        //---------------------------------------------------------------------
         private async IAsyncEnumerator<DataPoint> IterateCore(CancellationToken cancellationToken)
         {
             Debug.Assert(_asyncSource != null);
@@ -61,8 +47,7 @@ namespace gfoidl.DataCompression.Internal.NoCompression
             }
         }
         //---------------------------------------------------------------------
-        private async ValueTask BuildCollectionAsync<TBuilder>(TBuilder builder)
-            where TBuilder : ICollectionBuilder<DataPoint>
+        private protected override async ValueTask BuildCollectionAsync(ICollectionBuilder<DataPoint> builder)
         {
             await foreach (DataPoint dataPoint in _asyncSource.WithCancellation(_cancellationToken).ConfigureAwait(false))
             {

--- a/source/gfoidl.DataCompression/Compression/NoCompression/AsyncEnumerableIterator.cs
+++ b/source/gfoidl.DataCompression/Compression/NoCompression/AsyncEnumerableIterator.cs
@@ -28,12 +28,6 @@ namespace gfoidl.DataCompression.Internal.NoCompression
             return this.IterateCore(cancellationToken);
         }
         //---------------------------------------------------------------------
-        public override ValueTask<bool> MoveNextAsync()
-        {
-            ThrowHelper.ThrowInvalidOperation(ThrowHelper.ExceptionResource.GetEnumerator_must_be_called_first);
-            return default;
-        }
-        //---------------------------------------------------------------------
         private async IAsyncEnumerator<DataPoint> IterateCore(CancellationToken cancellationToken)
         {
             Debug.Assert(_asyncSource != null);

--- a/source/gfoidl.DataCompression/Compression/NoCompression/EnumerableIterator.cs
+++ b/source/gfoidl.DataCompression/Compression/NoCompression/EnumerableIterator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Threading;
 using System.Threading.Tasks;
 using gfoidl.DataCompression.Builders;
 
@@ -48,8 +49,8 @@ namespace gfoidl.DataCompression.Internal.NoCompression
         protected internal override ref (bool Archive, bool MaxDelta) IsPointToArchive(in DataPoint incoming, in DataPoint lastArchived) => throw new NotSupportedException();
         //---------------------------------------------------------------------
 #if NETSTANDARD2_1
-        public override ValueTask<DataPoint[]> ToArrayAsync()    => throw new NotSupportedException();
-        public override ValueTask<List<DataPoint>> ToListAsync() => throw new NotSupportedException();
+        public override ValueTask<DataPoint[]> ToArrayAsync(CancellationToken ct)    => throw new NotSupportedException();
+        public override ValueTask<List<DataPoint>> ToListAsync(CancellationToken ct) => throw new NotSupportedException();
 #endif
     }
 }

--- a/source/gfoidl.DataCompression/Compression/NoCompression/EnumerableIterator.cs
+++ b/source/gfoidl.DataCompression/Compression/NoCompression/EnumerableIterator.cs
@@ -48,7 +48,6 @@ namespace gfoidl.DataCompression.Internal.NoCompression
         protected internal override ref (bool Archive, bool MaxDelta) IsPointToArchive(in DataPoint incoming, in DataPoint lastArchived) => throw new NotSupportedException();
         //---------------------------------------------------------------------
 #if NETSTANDARD2_1
-        public override ValueTask<bool> MoveNextAsync()          => throw new NotSupportedException();
         public override ValueTask<DataPoint[]> ToArrayAsync()    => throw new NotSupportedException();
         public override ValueTask<List<DataPoint>> ToListAsync() => throw new NotSupportedException();
 #endif

--- a/source/gfoidl.DataCompression/Compression/NoCompression/NoCompression.cs
+++ b/source/gfoidl.DataCompression/Compression/NoCompression/NoCompression.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Threading;
 using gfoidl.DataCompression.Internal.NoCompression;
 
 namespace gfoidl.DataCompression
@@ -24,10 +23,9 @@ namespace gfoidl.DataCompression
         /// Implementation of the compression / filtering.
         /// </summary>
         /// <param name="data">Input data</param>
-        /// <param name="ct">The token for cancellation.</param>
         /// <returns>The compressed / filtered data.</returns>
-        protected override DataPointIterator ProcessAsyncCore(IAsyncEnumerable<DataPoint> data, CancellationToken ct)
-            => new AsyncEnumerableIterator(this, data, ct);
+        protected override DataPointIterator ProcessAsyncCore(IAsyncEnumerable<DataPoint> data)
+            => new AsyncEnumerableIterator(this, data);
 #endif
     }
 }

--- a/source/gfoidl.DataCompression/Compression/SwingingDoorCompression/AsyncEnumerableIterator.cs
+++ b/source/gfoidl.DataCompression/Compression/SwingingDoorCompression/AsyncEnumerableIterator.cs
@@ -1,20 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Threading;
 
 namespace gfoidl.DataCompression.Internal.SwingingDoor
 {
     internal sealed class AsyncEnumerableIterator : SwingingDoorCompressionIterator
     {
-        public AsyncEnumerableIterator(
-            SwingingDoorCompression      swingingDoorCompression,
-            IAsyncEnumerable<DataPoint>  source,
-            CancellationToken            cancellationToken = default)
+        public AsyncEnumerableIterator(SwingingDoorCompression swingingDoorCompression, IAsyncEnumerable<DataPoint> source)
             : base(swingingDoorCompression)
-        {
-            if (cancellationToken != default) _cancellationToken = cancellationToken;
-            _asyncSource = source;
-        }
+            => _asyncSource = source;
         //---------------------------------------------------------------------
         public override DataPointIterator Clone() => throw new NotSupportedException();
         public override bool MoveNext()           => throw new NotSupportedException();

--- a/source/gfoidl.DataCompression/Compression/SwingingDoorCompression/AsyncEnumerableIterator.cs
+++ b/source/gfoidl.DataCompression/Compression/SwingingDoorCompression/AsyncEnumerableIterator.cs
@@ -9,13 +9,11 @@ namespace gfoidl.DataCompression.Internal.SwingingDoor
         public AsyncEnumerableIterator(
             SwingingDoorCompression      swingingDoorCompression,
             IAsyncEnumerable<DataPoint>  source,
-            IAsyncEnumerator<DataPoint>? enumerator        = null,
             CancellationToken            cancellationToken = default)
             : base(swingingDoorCompression)
         {
             if (cancellationToken != default) _cancellationToken = cancellationToken;
-            _asyncSource     = source;
-            _asyncEnumerator = enumerator ?? source.GetAsyncEnumerator(_cancellationToken);
+            _asyncSource = source;
         }
         //---------------------------------------------------------------------
         public override DataPointIterator Clone() => throw new NotSupportedException();

--- a/source/gfoidl.DataCompression/Compression/SwingingDoorCompression/AsyncEnumerableIterator.cs
+++ b/source/gfoidl.DataCompression/Compression/SwingingDoorCompression/AsyncEnumerableIterator.cs
@@ -14,8 +14,8 @@ namespace gfoidl.DataCompression.Internal.SwingingDoor
             : base(swingingDoorCompression)
         {
             if (cancellationToken != default) _cancellationToken = cancellationToken;
-            _asyncSource                  = source;
-            _asyncEnumerator              = enumerator ?? source.GetAsyncEnumerator(_cancellationToken);
+            _asyncSource     = source;
+            _asyncEnumerator = enumerator ?? source.GetAsyncEnumerator(_cancellationToken);
         }
         //---------------------------------------------------------------------
         public override DataPointIterator Clone() => throw new NotSupportedException();

--- a/source/gfoidl.DataCompression/Compression/SwingingDoorCompression/IndexedIterator.cs
+++ b/source/gfoidl.DataCompression/Compression/SwingingDoorCompression/IndexedIterator.cs
@@ -42,7 +42,6 @@ namespace gfoidl.DataCompression.Internal.SwingingDoor
         protected internal override void Init(in DataPoint incoming, ref DataPoint snapShot)                   => throw new NotSupportedException();
         //---------------------------------------------------------------------
 #if NETSTANDARD2_1
-        public override ValueTask<bool> MoveNextAsync()          => throw new NotSupportedException();
         public override ValueTask<DataPoint[]> ToArrayAsync()    => throw new NotSupportedException();
         public override ValueTask<List<DataPoint>> ToListAsync() => throw new NotSupportedException();
 #endif

--- a/source/gfoidl.DataCompression/Compression/SwingingDoorCompression/IndexedIterator.cs
+++ b/source/gfoidl.DataCompression/Compression/SwingingDoorCompression/IndexedIterator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace gfoidl.DataCompression.Internal.SwingingDoor
@@ -42,8 +43,8 @@ namespace gfoidl.DataCompression.Internal.SwingingDoor
         protected internal override void Init(in DataPoint incoming, ref DataPoint snapShot)                   => throw new NotSupportedException();
         //---------------------------------------------------------------------
 #if NETSTANDARD2_1
-        public override ValueTask<DataPoint[]> ToArrayAsync()    => throw new NotSupportedException();
-        public override ValueTask<List<DataPoint>> ToListAsync() => throw new NotSupportedException();
+        public override ValueTask<DataPoint[]> ToArrayAsync(CancellationToken ct)    => throw new NotSupportedException();
+        public override ValueTask<List<DataPoint>> ToListAsync(CancellationToken ct) => throw new NotSupportedException();
 #endif
     }
 }

--- a/source/gfoidl.DataCompression/Compression/SwingingDoorCompression/SequentialEnumerableIterator.cs
+++ b/source/gfoidl.DataCompression/Compression/SwingingDoorCompression/SequentialEnumerableIterator.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace gfoidl.DataCompression.Internal.SwingingDoor
@@ -19,8 +20,8 @@ namespace gfoidl.DataCompression.Internal.SwingingDoor
         public override DataPointIterator Clone() => new SequentialEnumerableIterator(_swingingDoorCompression, _source, _enumerator);
         //---------------------------------------------------------------------
 #if NETSTANDARD2_1
-        public override ValueTask<DataPoint[]> ToArrayAsync()    => throw new NotSupportedException();
-        public override ValueTask<List<DataPoint>> ToListAsync() => throw new NotSupportedException();
+        public override ValueTask<DataPoint[]> ToArrayAsync(CancellationToken ct)    => throw new NotSupportedException();
+        public override ValueTask<List<DataPoint>> ToListAsync(CancellationToken ct) => throw new NotSupportedException();
 #endif
     }
 }

--- a/source/gfoidl.DataCompression/Compression/SwingingDoorCompression/SequentialEnumerableIterator.cs
+++ b/source/gfoidl.DataCompression/Compression/SwingingDoorCompression/SequentialEnumerableIterator.cs
@@ -19,7 +19,6 @@ namespace gfoidl.DataCompression.Internal.SwingingDoor
         public override DataPointIterator Clone() => new SequentialEnumerableIterator(_swingingDoorCompression, _source, _enumerator);
         //---------------------------------------------------------------------
 #if NETSTANDARD2_1
-        public override ValueTask<bool> MoveNextAsync()          => throw new NotSupportedException();
         public override ValueTask<DataPoint[]> ToArrayAsync()    => throw new NotSupportedException();
         public override ValueTask<List<DataPoint>> ToListAsync() => throw new NotSupportedException();
 #endif

--- a/source/gfoidl.DataCompression/Compression/SwingingDoorCompression/SwingingDoorCompression.cs
+++ b/source/gfoidl.DataCompression/Compression/SwingingDoorCompression/SwingingDoorCompression.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Threading;
 using gfoidl.DataCompression.Internal.SwingingDoor;
 using gfoidl.DataCompression.Wrappers;
 
@@ -104,10 +103,9 @@ namespace gfoidl.DataCompression
         /// Implementation of the compression / filtering.
         /// </summary>
         /// <param name="data">Input data</param>
-        /// <param name="ct">The token for cancellation.</param>
         /// <returns>The compressed / filtered data.</returns>
-        protected override DataPointIterator ProcessAsyncCore(IAsyncEnumerable<DataPoint> data, CancellationToken ct)
-            => new AsyncEnumerableIterator(this, data, cancellationToken: ct);
+        protected override DataPointIterator ProcessAsyncCore(IAsyncEnumerable<DataPoint> data)
+            => new AsyncEnumerableIterator(this, data);
 #endif
     }
 }

--- a/source/gfoidl.DataCompression/DataPointIterator.Async.cs
+++ b/source/gfoidl.DataCompression/DataPointIterator.Async.cs
@@ -86,7 +86,7 @@ namespace gfoidl.DataCompression
                     return false;
                 case 2:
                     if (_algorithm._minDeltaXHasValue)
-                        await this.SkipMinDeltaXAsync(_snapShot.X).ConfigureAwait(false);
+                        await this.SkipMinDeltaXAsync(_asyncEnumerator, _snapShot.X).ConfigureAwait(false);
 
                     _current = _incoming;
                     _state   = 1;
@@ -179,7 +179,7 @@ namespace gfoidl.DataCompression
 
                 if (_algorithm._minDeltaXHasValue)
                 {
-                    await this.SkipMinDeltaXAsync(snapShot.X).ConfigureAwait(false);
+                    await this.SkipMinDeltaXAsync(enumerator, snapShot.X).ConfigureAwait(false);
                     incoming = _incoming;
                 }
 
@@ -192,14 +192,13 @@ namespace gfoidl.DataCompression
         }
         //---------------------------------------------------------------------
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private async ValueTask SkipMinDeltaXAsync(double snapShotX)
+        private async ValueTask SkipMinDeltaXAsync(IAsyncEnumerator<DataPoint> asyncEnumerator, double snapShotX)
         {
-            Debug.Assert(_asyncEnumerator != null);
             double minDeltaX = _algorithm._minDeltaX;
 
-            while (await _asyncEnumerator.MoveNextAsync().ConfigureAwait(false))
+            while (await asyncEnumerator.MoveNextAsync().ConfigureAwait(false))
             {
-                DataPoint tmp = _asyncEnumerator.Current;
+                DataPoint tmp = asyncEnumerator.Current;
 
                 if ((tmp.X - snapShotX) > minDeltaX)
                 {

--- a/source/gfoidl.DataCompression/DataPointIterator.Async.cs
+++ b/source/gfoidl.DataCompression/DataPointIterator.Async.cs
@@ -111,7 +111,8 @@ namespace gfoidl.DataCompression
                 yield return _incoming;
         }
         //---------------------------------------------------------------------
-        private protected virtual async ValueTask BuildCollectionAsync(ICollectionBuilder<DataPoint> builder, CancellationToken cancellationToken)
+        private protected virtual async ValueTask BuildCollectionAsync<TBuilder>(TBuilder builder, CancellationToken cancellationToken)
+            where TBuilder : ICollectionBuilder<DataPoint>
         {
             await foreach (DataPoint dataPoint in this.WithCancellation(cancellationToken).ConfigureAwait(false))
             {

--- a/source/gfoidl.DataCompression/DataPointIterator.Async.cs
+++ b/source/gfoidl.DataCompression/DataPointIterator.Async.cs
@@ -23,7 +23,7 @@ namespace gfoidl.DataCompression
         /// Gets an enumerator for the <see cref="DataPoint" />s.
         /// </summary>
         /// <returns>The enumerator.</returns>
-        public DataPointIterator GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        public virtual IAsyncEnumerator<DataPoint> GetAsyncEnumerator(CancellationToken cancellationToken = default)
         {
             if (cancellationToken != default)
                 _cancellationToken = cancellationToken;

--- a/source/gfoidl.DataCompression/EmptyDataPointIterator.cs
+++ b/source/gfoidl.DataCompression/EmptyDataPointIterator.cs
@@ -14,7 +14,6 @@ namespace gfoidl.DataCompression
         public override List<DataPoint> ToList()  => new List<DataPoint>();
         //---------------------------------------------------------------------
 #if NETSTANDARD2_1
-        public override ValueTask<bool> MoveNextAsync()          => new ValueTask<bool>(false);
         public override ValueTask<DataPoint[]> ToArrayAsync()    => new ValueTask<DataPoint[]>(Array.Empty<DataPoint>());
         public override ValueTask<List<DataPoint>> ToListAsync() => new ValueTask<List<DataPoint>>(new List<DataPoint>());
 #endif

--- a/source/gfoidl.DataCompression/EmptyDataPointIterator.cs
+++ b/source/gfoidl.DataCompression/EmptyDataPointIterator.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace gfoidl.DataCompression
@@ -14,8 +15,8 @@ namespace gfoidl.DataCompression
         public override List<DataPoint> ToList()  => new List<DataPoint>();
         //---------------------------------------------------------------------
 #if NETSTANDARD2_1
-        public override ValueTask<DataPoint[]> ToArrayAsync()    => new ValueTask<DataPoint[]>(Array.Empty<DataPoint>());
-        public override ValueTask<List<DataPoint>> ToListAsync() => new ValueTask<List<DataPoint>>(new List<DataPoint>());
+        public override ValueTask<DataPoint[]> ToArrayAsync(CancellationToken ct)    => new ValueTask<DataPoint[]>(Array.Empty<DataPoint>());
+        public override ValueTask<List<DataPoint>> ToListAsync(CancellationToken ct) => new ValueTask<List<DataPoint>>(new List<DataPoint>());
 #endif
         //---------------------------------------------------------------------
         protected internal override void Init(in DataPoint incoming, ref DataPoint snapShot)                                             => throw new NotSupportedException();

--- a/source/gfoidl.DataCompression/ExtensionMethods.cs
+++ b/source/gfoidl.DataCompression/ExtensionMethods.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Threading;
 
 namespace gfoidl.DataCompression
 {
@@ -122,17 +121,16 @@ namespace gfoidl.DataCompression
         /// A filter that performs no compression.
         /// </summary>
         /// <param name="data">Input data</param>
-        /// <param name="ct">The token for cancellation.</param>
         /// <returns>The unmodified input data.</returns>
         /// <exception cref="ArgumentNullException">
         /// <paramref name="data" /> is <c>null</c>
         /// </exception>
-        public static DataPointIterator NoCompressionAsync(this IAsyncEnumerable<DataPoint>? data, CancellationToken ct = default)
+        public static DataPointIterator NoCompressionAsync(this IAsyncEnumerable<DataPoint>? data)
         {
             if (data is null) ThrowHelper.ThrowArgumentNull(ThrowHelper.ExceptionArgument.data);
 
             var compression = new NoCompression();
-            return compression.ProcessAsync(data, ct);
+            return compression.ProcessAsync(data);
         }
         //---------------------------------------------------------------------
         /// <summary>
@@ -147,17 +145,16 @@ namespace gfoidl.DataCompression
         /// Length of x/time within no value gets recorded (after the last archived value).
         /// See <see cref="Compression.MinDeltaX" />.
         /// </param>
-        /// <param name="ct">The token for cancellation.</param>
         /// <returns>Dead band compressed / filtered data.</returns>
         /// <exception cref="ArgumentNullException">
         /// <paramref name="data" /> is <c>null</c>
         /// </exception>
-        public static DataPointIterator DeadBandCompressionAsync(this IAsyncEnumerable<DataPoint>? data, double instrumentPrecision, double? maxDeltaX = null, double? minDeltaX = null, CancellationToken ct = default)
+        public static DataPointIterator DeadBandCompressionAsync(this IAsyncEnumerable<DataPoint>? data, double instrumentPrecision, double? maxDeltaX = null, double? minDeltaX = null)
         {
             if (data is null) ThrowHelper.ThrowArgumentNull(ThrowHelper.ExceptionArgument.data);
 
             var compression = new DeadBandCompression(instrumentPrecision, maxDeltaX, minDeltaX);
-            return compression.ProcessAsync(data, ct);
+            return compression.ProcessAsync(data);
         }
         //---------------------------------------------------------------------
         /// <summary>
@@ -168,16 +165,15 @@ namespace gfoidl.DataCompression
         /// <param name="maxTime">Length of time before for sure a value gets recoreded</param>
         /// <param name="minTime">Length of time within no value gets recorded (after the last archived value)</param>
         /// <returns>Dead band compressed / filtered data.</returns>
-        /// <param name="ct">The token for cancellation.</param>
         /// <exception cref="ArgumentNullException">
         /// <paramref name="data" /> is <c>null</c>
         /// </exception>
-        public static DataPointIterator DeadBandCompressionAsync(this IAsyncEnumerable<DataPoint>? data, double instrumentPrecision, TimeSpan maxTime, TimeSpan? minTime = null, CancellationToken ct = default)
+        public static DataPointIterator DeadBandCompressionAsync(this IAsyncEnumerable<DataPoint>? data, double instrumentPrecision, TimeSpan maxTime, TimeSpan? minTime = null)
         {
             if (data is null) ThrowHelper.ThrowArgumentNull(ThrowHelper.ExceptionArgument.data);
 
             var compression = new DeadBandCompression(instrumentPrecision, maxTime, minTime);
-            return compression.ProcessAsync(data, ct);
+            return compression.ProcessAsync(data);
         }
         //---------------------------------------------------------------------
         /// <summary>
@@ -195,17 +191,16 @@ namespace gfoidl.DataCompression
         /// Length of x/time within no value gets recorded (after the last archived value).
         /// See <see cref="Compression.MinDeltaX" />.
         /// </param>
-        /// <param name="ct">The token for cancellation.</param>
         /// <returns>swinging door compressed / filtered data.</returns>
         /// <exception cref="ArgumentNullException">
         /// <paramref name="data" /> is <c>null</c>
         /// </exception>
-        public static DataPointIterator SwingingDoorCompressionAsync(this IAsyncEnumerable<DataPoint>? data, double compressionDeviation, double? maxDeltaX = null, double? minDeltaX = null, CancellationToken ct = default)
+        public static DataPointIterator SwingingDoorCompressionAsync(this IAsyncEnumerable<DataPoint>? data, double compressionDeviation, double? maxDeltaX = null, double? minDeltaX = null)
         {
             if (data is null) ThrowHelper.ThrowArgumentNull(ThrowHelper.ExceptionArgument.data);
 
             var compression = new SwingingDoorCompression(compressionDeviation, maxDeltaX, minDeltaX);
-            return compression.ProcessAsync(data, ct);
+            return compression.ProcessAsync(data);
         }
         //---------------------------------------------------------------------
         /// <summary>
@@ -218,17 +213,16 @@ namespace gfoidl.DataCompression
         /// </param>
         /// <param name="maxTime">Length of time before for sure a value gets recoreded</param>
         /// <param name="minTime">Length of time within no value gets recorded (after the last archived value)</param>
-        /// <param name="ct">The token for cancellation.</param>
         /// <returns>swinging door compressed / filtered data.</returns>
         /// <exception cref="ArgumentNullException">
         /// <paramref name="data" /> is <c>null</c>
         /// </exception>
-        public static DataPointIterator SwingingDoorCompressionAsync(this IAsyncEnumerable<DataPoint>? data, double compressionDeviation, TimeSpan maxTime, TimeSpan? minTime = null, CancellationToken ct = default)
+        public static DataPointIterator SwingingDoorCompressionAsync(this IAsyncEnumerable<DataPoint>? data, double compressionDeviation, TimeSpan maxTime, TimeSpan? minTime = null)
         {
             if (data is null) ThrowHelper.ThrowArgumentNull(ThrowHelper.ExceptionArgument.data);
 
             var compression = new SwingingDoorCompression(compressionDeviation, maxTime, minTime);
-            return compression.ProcessAsync(data, ct);
+            return compression.ProcessAsync(data);
         }
 #endif
     }

--- a/source/gfoidl.DataCompression/ICompression.cs
+++ b/source/gfoidl.DataCompression/ICompression.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Threading;
 
 namespace gfoidl.DataCompression
 {
@@ -40,9 +39,8 @@ namespace gfoidl.DataCompression
         /// Performs the compression / filtering of the input data.
         /// </summary>
         /// <param name="data">Input data</param>
-        /// <param name="ct">The token for cancellation.</param>
         /// <returns>The compressed / filtered data.</returns>
-        DataPointIterator ProcessAsync(IAsyncEnumerable<DataPoint>? data, CancellationToken ct = default);
+        DataPointIterator ProcessAsync(IAsyncEnumerable<DataPoint>? data);
 #endif
     }
 }

--- a/tests/gfoidl.DataCompression.Tests/Compression/DeadBandCompressionTests/MoveNextAsync.cs
+++ b/tests/gfoidl.DataCompression.Tests/Compression/DeadBandCompressionTests/MoveNextAsync.cs
@@ -8,17 +8,6 @@ namespace gfoidl.DataCompression.Tests.Compression.DeadBandCompressionTests
     public class MoveNextAsync : Base
     {
         [Test]
-        public void MoveNext_without_GetEnumerator___throws_InvalidOperation()
-        {
-            var sut  = new DeadBandCompression(1);
-            var data = RawDataForTrendAsync();
-
-            var iterator = sut.ProcessAsync(data);
-
-            Assert.ThrowsAsync<InvalidOperationException>(async () => await iterator.MoveNextAsync());
-        }
-        //---------------------------------------------------------------------
-        [Test]
         public async Task Empty_IAsyncEnumerable___empty_result()
         {
             var sut      = new DeadBandCompression(0.1);

--- a/tests/gfoidl.DataCompression.Tests/Compression/DeadBandCompressionTests/ProcessAsyncCore.cs
+++ b/tests/gfoidl.DataCompression.Tests/Compression/DeadBandCompressionTests/ProcessAsyncCore.cs
@@ -36,7 +36,7 @@ namespace gfoidl.DataCompression.Tests.Compression.DeadBandCompressionTests
 
             Assert.ThrowsAsync<OperationCanceledException>(async () =>
             {
-                await foreach (DataPoint dp in sut.ProcessAsync(data, cts.Token))
+                await foreach (DataPoint dp in sut.ProcessAsync(data).WithCancellation(cts.Token))
                 {
                     actual.Add(dp);
                     idx++;

--- a/tests/gfoidl.DataCompression.Tests/Compression/DeadBandCompressionTests/ToArrayAsync.cs
+++ b/tests/gfoidl.DataCompression.Tests/Compression/DeadBandCompressionTests/ToArrayAsync.cs
@@ -80,7 +80,7 @@ namespace gfoidl.DataCompression.Tests.Compression.DeadBandCompressionTests
             cts.Cancel();
 
             DataPoint[] res = null;
-            Assert.ThrowsAsync<OperationCanceledException>(async () => res = await dataPointIterator.ToArrayAsync());
+            Assert.ThrowsAsync<OperationCanceledException>(async () => res = await dataPointIterator.ToArrayAsync(cts.Token));
 
             CollectionAssert.AreEqual(expected, actual);
             Assert.IsNull(res);

--- a/tests/gfoidl.DataCompression.Tests/Compression/DeadBandCompressionTests/ToArrayAsync.cs
+++ b/tests/gfoidl.DataCompression.Tests/Compression/DeadBandCompressionTests/ToArrayAsync.cs
@@ -52,7 +52,7 @@ namespace gfoidl.DataCompression.Tests.Compression.DeadBandCompressionTests
             var expected = ExpectedForTrend().ToList();
 
             DataPointIterator dataPointIterator = sut.ProcessAsync(data);
-            DataPointIterator enumerator        = dataPointIterator.GetAsyncEnumerator();
+            var enumerator                      = dataPointIterator.GetAsyncEnumerator();
 
             await enumerator.MoveNextAsync();
             await enumerator.MoveNextAsync();
@@ -70,7 +70,7 @@ namespace gfoidl.DataCompression.Tests.Compression.DeadBandCompressionTests
 
             DataPointIterator dataPointIterator = sut.ProcessAsync(data);
             var cts                             = new CancellationTokenSource();
-            DataPointIterator enumerator        = dataPointIterator.GetAsyncEnumerator(cts.Token);
+            var enumerator                      = dataPointIterator.GetAsyncEnumerator(cts.Token);
 
             var actual = new List<DataPoint>();
             await enumerator.MoveNextAsync();

--- a/tests/gfoidl.DataCompression.Tests/Compression/DeadBandCompressionTests/ToListAsync.cs
+++ b/tests/gfoidl.DataCompression.Tests/Compression/DeadBandCompressionTests/ToListAsync.cs
@@ -69,7 +69,7 @@ namespace gfoidl.DataCompression.Tests.Compression.DeadBandCompressionTests
             cts.Cancel();
 
             List<DataPoint> res = null;
-            Assert.ThrowsAsync<OperationCanceledException>(async () => res = await dataPointIterator.ToListAsync());
+            Assert.ThrowsAsync<OperationCanceledException>(async () => res = await dataPointIterator.ToListAsync(cts.Token));
 
             CollectionAssert.AreEqual(expected, actual);
             Assert.IsNull(res);

--- a/tests/gfoidl.DataCompression.Tests/Compression/DeadBandCompressionTests/ToListAsync.cs
+++ b/tests/gfoidl.DataCompression.Tests/Compression/DeadBandCompressionTests/ToListAsync.cs
@@ -41,7 +41,7 @@ namespace gfoidl.DataCompression.Tests.Compression.DeadBandCompressionTests
             var expected = ExpectedForTrend().ToList();
 
             DataPointIterator dataPointIterator = sut.ProcessAsync(data);
-            DataPointIterator enumerator        = dataPointIterator.GetAsyncEnumerator();
+            var enumerator                      = dataPointIterator.GetAsyncEnumerator();
 
             await enumerator.MoveNextAsync();
             await enumerator.MoveNextAsync();
@@ -59,7 +59,7 @@ namespace gfoidl.DataCompression.Tests.Compression.DeadBandCompressionTests
 
             DataPointIterator dataPointIterator = sut.ProcessAsync(data);
             var cts                             = new CancellationTokenSource();
-            DataPointIterator enumerator        = dataPointIterator.GetAsyncEnumerator(cts.Token);
+            var enumerator                      = dataPointIterator.GetAsyncEnumerator(cts.Token);
 
             var actual = new List<DataPoint>();
             await enumerator.MoveNextAsync();

--- a/tests/gfoidl.DataCompression.Tests/Compression/NoCompressionTests/MoveNextAsync.cs
+++ b/tests/gfoidl.DataCompression.Tests/Compression/NoCompressionTests/MoveNextAsync.cs
@@ -8,17 +8,6 @@ namespace gfoidl.DataCompression.Tests.Compression.NoCompressionTests
     public class MoveNextAsync : Base
     {
         [Test]
-        public void MoveNext_without_GetEnumerator___throws_InvalidOperation()
-        {
-            var sut  = new NoCompression();
-            var data = RawDataForTrendAsync();
-
-            var iterator = sut.ProcessAsync(data);
-
-            Assert.ThrowsAsync<InvalidOperationException>(async () => await iterator.MoveNextAsync());
-        }
-        //---------------------------------------------------------------------
-        [Test]
         public async Task Empty_IAsyncEnumerable___empty_result()
         {
             var sut      = new NoCompression();

--- a/tests/gfoidl.DataCompression.Tests/Compression/NoCompressionTests/ProcessAsyncCore.cs
+++ b/tests/gfoidl.DataCompression.Tests/Compression/NoCompressionTests/ProcessAsyncCore.cs
@@ -36,56 +36,6 @@ namespace gfoidl.DataCompression.Tests.Compression.NoCompressionTests
 
             Assert.ThrowsAsync<OperationCanceledException>(async () =>
             {
-                await foreach (DataPoint dp in sut.ProcessAsync(data, cts.Token))
-                {
-                    actual.Add(dp);
-                    idx++;
-
-                    if (idx == 2) cts.Cancel();
-                }
-            });
-
-            CollectionAssert.AreEqual(actual, expected);
-        }
-        //---------------------------------------------------------------------
-        [Test]
-        public void Cancellation_after_two_items_WithCancellation___OK()
-        {
-            var sut      = new NoCompression();
-            var data     = RawDataForTrendAsync();
-            var expected = RawDataForTrend().Take(2).ToList();
-            var cts      = new CancellationTokenSource();
-
-            var actual = new List<DataPoint>();
-            int idx    = 0;
-
-            Assert.ThrowsAsync<OperationCanceledException>(async () =>
-            {
-                await foreach (DataPoint dp in sut.ProcessAsync(data, cts.Token).WithCancellation(cts.Token))
-                {
-                    actual.Add(dp);
-                    idx++;
-
-                    if (idx == 2) cts.Cancel();
-                }
-            });
-
-            CollectionAssert.AreEqual(actual, expected);
-        }
-        //---------------------------------------------------------------------
-        [Test]
-        public void Cancellation_after_two_items_WithCancellation_only___OK()
-        {
-            var sut      = new NoCompression();
-            var data     = RawDataForTrendAsync();
-            var expected = RawDataForTrend().Take(2).ToList();
-            var cts      = new CancellationTokenSource();
-
-            var actual = new List<DataPoint>();
-            int idx    = 0;
-
-            Assert.ThrowsAsync<OperationCanceledException>(async () =>
-            {
                 await foreach (DataPoint dp in sut.ProcessAsync(data).WithCancellation(cts.Token))
                 {
                     actual.Add(dp);

--- a/tests/gfoidl.DataCompression.Tests/Compression/NoCompressionTests/ProcessAsyncCore.cs
+++ b/tests/gfoidl.DataCompression.Tests/Compression/NoCompressionTests/ProcessAsyncCore.cs
@@ -49,6 +49,56 @@ namespace gfoidl.DataCompression.Tests.Compression.NoCompressionTests
         }
         //---------------------------------------------------------------------
         [Test]
+        public void Cancellation_after_two_items_WithCancellation___OK()
+        {
+            var sut      = new NoCompression();
+            var data     = RawDataForTrendAsync();
+            var expected = RawDataForTrend().Take(2).ToList();
+            var cts      = new CancellationTokenSource();
+
+            var actual = new List<DataPoint>();
+            int idx    = 0;
+
+            Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            {
+                await foreach (DataPoint dp in sut.ProcessAsync(data, cts.Token).WithCancellation(cts.Token))
+                {
+                    actual.Add(dp);
+                    idx++;
+
+                    if (idx == 2) cts.Cancel();
+                }
+            });
+
+            CollectionAssert.AreEqual(actual, expected);
+        }
+        //---------------------------------------------------------------------
+        [Test]
+        public void Cancellation_after_two_items_WithCancellation_only___OK()
+        {
+            var sut      = new NoCompression();
+            var data     = RawDataForTrendAsync();
+            var expected = RawDataForTrend().Take(2).ToList();
+            var cts      = new CancellationTokenSource();
+
+            var actual = new List<DataPoint>();
+            int idx    = 0;
+
+            Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            {
+                await foreach (DataPoint dp in sut.ProcessAsync(data).WithCancellation(cts.Token))
+                {
+                    actual.Add(dp);
+                    idx++;
+
+                    if (idx == 2) cts.Cancel();
+                }
+            });
+
+            CollectionAssert.AreEqual(actual, expected);
+        }
+        //---------------------------------------------------------------------
+        [Test]
         public async Task Data_IAsyncEnumerable_with_maxDeltaX___OK()
         {
             var sut      = new NoCompression();

--- a/tests/gfoidl.DataCompression.Tests/Compression/NoCompressionTests/ToArrayAsync.cs
+++ b/tests/gfoidl.DataCompression.Tests/Compression/NoCompressionTests/ToArrayAsync.cs
@@ -41,7 +41,7 @@ namespace gfoidl.DataCompression.Tests.Compression.NoCompressionTests
             var expected = RawDataForTrend().ToList();
 
             DataPointIterator dataPointIterator = sut.ProcessAsync(data);
-            DataPointIterator enumerator        = dataPointIterator.GetAsyncEnumerator();
+            var enumerator                      = dataPointIterator.GetAsyncEnumerator();
 
             await enumerator.MoveNextAsync();
             await enumerator.MoveNextAsync();
@@ -59,7 +59,7 @@ namespace gfoidl.DataCompression.Tests.Compression.NoCompressionTests
 
             DataPointIterator dataPointIterator = sut.ProcessAsync(data);
             var cts                             = new CancellationTokenSource();
-            DataPointIterator enumerator        = dataPointIterator.GetAsyncEnumerator(cts.Token);
+            var enumerator                      = dataPointIterator.GetAsyncEnumerator(cts.Token);
 
             var actual = new List<DataPoint>();
             await enumerator.MoveNextAsync();

--- a/tests/gfoidl.DataCompression.Tests/Compression/NoCompressionTests/ToArrayAsync.cs
+++ b/tests/gfoidl.DataCompression.Tests/Compression/NoCompressionTests/ToArrayAsync.cs
@@ -69,7 +69,7 @@ namespace gfoidl.DataCompression.Tests.Compression.NoCompressionTests
             cts.Cancel();
 
             DataPoint[] res = null;
-            Assert.ThrowsAsync<OperationCanceledException>(async () => res = await dataPointIterator.ToArrayAsync());
+            Assert.ThrowsAsync<OperationCanceledException>(async () => res = await dataPointIterator.ToArrayAsync(cts.Token));
 
             CollectionAssert.AreEqual(expected, actual);
             Assert.IsNull(res);

--- a/tests/gfoidl.DataCompression.Tests/Compression/NoCompressionTests/ToListAsync.cs
+++ b/tests/gfoidl.DataCompression.Tests/Compression/NoCompressionTests/ToListAsync.cs
@@ -41,7 +41,7 @@ namespace gfoidl.DataCompression.Tests.Compression.NoCompressionTests
             var expected = RawDataForTrend().ToList();
 
             DataPointIterator dataPointIterator = sut.ProcessAsync(data);
-            DataPointIterator enumerator        = dataPointIterator.GetAsyncEnumerator();
+            var enumerator                      = dataPointIterator.GetAsyncEnumerator();
 
             await enumerator.MoveNextAsync();
             await enumerator.MoveNextAsync();
@@ -59,7 +59,7 @@ namespace gfoidl.DataCompression.Tests.Compression.NoCompressionTests
 
             DataPointIterator dataPointIterator = sut.ProcessAsync(data);
             var cts                             = new CancellationTokenSource();
-            DataPointIterator enumerator        = dataPointIterator.GetAsyncEnumerator(cts.Token);
+            var enumerator                      = dataPointIterator.GetAsyncEnumerator(cts.Token);
 
             var actual = new List<DataPoint>();
             await enumerator.MoveNextAsync();

--- a/tests/gfoidl.DataCompression.Tests/Compression/NoCompressionTests/ToListAsync.cs
+++ b/tests/gfoidl.DataCompression.Tests/Compression/NoCompressionTests/ToListAsync.cs
@@ -69,7 +69,7 @@ namespace gfoidl.DataCompression.Tests.Compression.NoCompressionTests
             cts.Cancel();
 
             List<DataPoint> res = null;
-            Assert.ThrowsAsync<OperationCanceledException>(async () => res = await dataPointIterator.ToListAsync());
+            Assert.ThrowsAsync<OperationCanceledException>(async () => res = await dataPointIterator.ToListAsync(cts.Token));
 
             CollectionAssert.AreEqual(expected, actual);
             Assert.IsNull(res);

--- a/tests/gfoidl.DataCompression.Tests/Compression/SwingingDoorCompressionTests/Base.cs
+++ b/tests/gfoidl.DataCompression.Tests/Compression/SwingingDoorCompressionTests/Base.cs
@@ -12,6 +12,8 @@ namespace gfoidl.DataCompression.Tests.Compression.SwingingDoorCompressionTests
     {
         private static readonly DataPointSerializer s_ser = new DataPointSerializer();
         //---------------------------------------------------------------------
+        protected static int RawMinDeltaXCounter { get; private set; }
+        //---------------------------------------------------------------------
         protected static IEnumerable<DataPoint> RawDataForTrend()     => s_ser.Read("../../../../../doc/data/swinging-door/trend_raw.csv");
         protected static IEnumerable<DataPoint> ExpectedForTrend()    => s_ser.Read("../../../../../doc/data/swinging-door/trend_compressed.csv");
         protected static IEnumerable<DataPoint> RawDataForMaxDelta()  => s_ser.Read("../../../../../doc/data/swinging-door/maxDelta_raw.csv");
@@ -19,6 +21,8 @@ namespace gfoidl.DataCompression.Tests.Compression.SwingingDoorCompressionTests
         //---------------------------------------------------------------------
         protected static IEnumerable<DataPoint> RawMinDeltaX()
         {
+            RawMinDeltaXCounter++;
+
             yield return (0d, 2d);
             yield return (1d, 2d);
             yield return (2d, 2d);

--- a/tests/gfoidl.DataCompression.Tests/Compression/SwingingDoorCompressionTests/MoveNextAsync.cs
+++ b/tests/gfoidl.DataCompression.Tests/Compression/SwingingDoorCompressionTests/MoveNextAsync.cs
@@ -8,17 +8,6 @@ namespace gfoidl.DataCompression.Tests.Compression.SwingingDoorCompressionTests
     public class MoveNextAsync : Base
     {
         [Test]
-        public void MoveNext_without_GetEnumerator___throws_InvalidOperation()
-        {
-            var sut  = new SwingingDoorCompression(1);
-            var data = RawDataForTrendAsync();
-
-            var iterator = sut.ProcessAsync(data);
-
-            Assert.ThrowsAsync<InvalidOperationException>(async () => await iterator.MoveNextAsync());
-        }
-        //---------------------------------------------------------------------
-        [Test]
         public async Task Empty_IAsyncEnumerable___empty_result()
         {
             var sut      = new SwingingDoorCompression(1);

--- a/tests/gfoidl.DataCompression.Tests/Compression/SwingingDoorCompressionTests/ProcessAsyncCore.cs
+++ b/tests/gfoidl.DataCompression.Tests/Compression/SwingingDoorCompressionTests/ProcessAsyncCore.cs
@@ -47,7 +47,7 @@ namespace gfoidl.DataCompression.Tests.Compression.SwingingDoorCompressionTests
                 }
             });
 
-            CollectionAssert.AreEqual(actual, expected);
+            CollectionAssert.AreEqual(expected, actual);
         }
         //---------------------------------------------------------------------
         [Test]

--- a/tests/gfoidl.DataCompression.Tests/Compression/SwingingDoorCompressionTests/ProcessAsyncCore.cs
+++ b/tests/gfoidl.DataCompression.Tests/Compression/SwingingDoorCompressionTests/ProcessAsyncCore.cs
@@ -77,5 +77,20 @@ namespace gfoidl.DataCompression.Tests.Compression.SwingingDoorCompressionTests
 
             CollectionAssert.AreEqual(expected, actual);
         }
+        //---------------------------------------------------------------------
+        [Test]
+        public async Task Data_IAsyncEnumerable_with_minDeltaX_ToArray___OK()
+        {
+            int currentRawMinDeltaXCount = RawMinDeltaXCounter;
+
+            var sut      = new SwingingDoorCompression(1d, minDeltaX: 1d);
+            var data     = RawMinDeltaXAsync();
+            var expected = ExpectedMinDeltaX().ToList();
+
+            var actual = await sut.ProcessAsync(data).ToArrayAsync();
+
+            CollectionAssert.AreEqual(expected, actual);
+            Assert.AreEqual(currentRawMinDeltaXCount + 1, RawMinDeltaXCounter);
+        }
     }
 }

--- a/tests/gfoidl.DataCompression.Tests/Compression/SwingingDoorCompressionTests/ProcessAsyncCore.cs
+++ b/tests/gfoidl.DataCompression.Tests/Compression/SwingingDoorCompressionTests/ProcessAsyncCore.cs
@@ -38,7 +38,7 @@ namespace gfoidl.DataCompression.Tests.Compression.SwingingDoorCompressionTests
 
             Assert.ThrowsAsync<OperationCanceledException>(async () =>
             {
-                await foreach (DataPoint dp in sut.ProcessAsync(data, cts.Token))
+                await foreach (DataPoint dp in sut.ProcessAsync(data).WithCancellation(cts.Token))
                 {
                     actual.Add(dp);
                     idx++;

--- a/tests/gfoidl.DataCompression.Tests/Compression/SwingingDoorCompressionTests/ToArrayAsync.cs
+++ b/tests/gfoidl.DataCompression.Tests/Compression/SwingingDoorCompressionTests/ToArrayAsync.cs
@@ -53,7 +53,7 @@ namespace gfoidl.DataCompression.Tests.Compression.SwingingDoorCompressionTests
             var expected = ExpectedForTrend().ToList();
 
             DataPointIterator dataPointIterator = sut.ProcessAsync(data);
-            DataPointIterator enumerator        = dataPointIterator.GetAsyncEnumerator();
+            var enumerator                      = dataPointIterator.GetAsyncEnumerator();
 
             await enumerator.MoveNextAsync();
             await enumerator.MoveNextAsync();
@@ -71,7 +71,7 @@ namespace gfoidl.DataCompression.Tests.Compression.SwingingDoorCompressionTests
 
             DataPointIterator dataPointIterator = sut.ProcessAsync(data);
             var cts                             = new CancellationTokenSource();
-            DataPointIterator enumerator        = dataPointIterator.GetAsyncEnumerator(cts.Token);
+            var enumerator                      = dataPointIterator.GetAsyncEnumerator(cts.Token);
 
             var actual = new List<DataPoint>();
             await enumerator.MoveNextAsync();

--- a/tests/gfoidl.DataCompression.Tests/Compression/SwingingDoorCompressionTests/ToArrayAsync.cs
+++ b/tests/gfoidl.DataCompression.Tests/Compression/SwingingDoorCompressionTests/ToArrayAsync.cs
@@ -81,7 +81,7 @@ namespace gfoidl.DataCompression.Tests.Compression.SwingingDoorCompressionTests
             cts.Cancel();
 
             DataPoint[] res = null;
-            Assert.ThrowsAsync<OperationCanceledException>(async () => res = await dataPointIterator.ToArrayAsync());
+            Assert.ThrowsAsync<OperationCanceledException>(async () => res = await dataPointIterator.ToArrayAsync(cts.Token));
 
             CollectionAssert.AreEqual(expected, actual);
             Assert.IsNull(res);

--- a/tests/gfoidl.DataCompression.Tests/Compression/SwingingDoorCompressionTests/ToListAsync.cs
+++ b/tests/gfoidl.DataCompression.Tests/Compression/SwingingDoorCompressionTests/ToListAsync.cs
@@ -69,7 +69,7 @@ namespace gfoidl.DataCompression.Tests.Compression.SwingingDoorCompressionTests
             cts.Cancel();
 
             List<DataPoint> res = null;
-            Assert.ThrowsAsync<OperationCanceledException>(async () => res = await dataPointIterator.ToListAsync());
+            Assert.ThrowsAsync<OperationCanceledException>(async () => res = await dataPointIterator.ToListAsync(cts.Token));
 
             CollectionAssert.AreEqual(expected, actual);
             Assert.IsNull(res);

--- a/tests/gfoidl.DataCompression.Tests/Compression/SwingingDoorCompressionTests/ToListAsync.cs
+++ b/tests/gfoidl.DataCompression.Tests/Compression/SwingingDoorCompressionTests/ToListAsync.cs
@@ -41,7 +41,7 @@ namespace gfoidl.DataCompression.Tests.Compression.SwingingDoorCompressionTests
             var expected = ExpectedForTrend().ToList();
 
             DataPointIterator dataPointIterator = sut.ProcessAsync(data);
-            DataPointIterator enumerator        = dataPointIterator.GetAsyncEnumerator();
+            var enumerator                      = dataPointIterator.GetAsyncEnumerator();
 
             await enumerator.MoveNextAsync();
             await enumerator.MoveNextAsync();
@@ -59,7 +59,7 @@ namespace gfoidl.DataCompression.Tests.Compression.SwingingDoorCompressionTests
 
             DataPointIterator dataPointIterator = sut.ProcessAsync(data);
             var cts                             = new CancellationTokenSource();
-            DataPointIterator enumerator        = dataPointIterator.GetAsyncEnumerator(cts.Token);
+            var enumerator                      = dataPointIterator.GetAsyncEnumerator(cts.Token);
 
             var actual = new List<DataPoint>();
             await enumerator.MoveNextAsync();

--- a/tests/gfoidl.DataCompression.Tests/DataPointIteratorTests/Empty.cs
+++ b/tests/gfoidl.DataCompression.Tests/DataPointIteratorTests/Empty.cs
@@ -24,7 +24,6 @@ namespace gfoidl.DataCompression.Tests.DataPointIteratorTests
         {
             DataPointIterator sut = DataPointIterator.Empty;
 
-            Assert.IsFalse(await sut.MoveNextAsync());
             Assert.AreSame(Array.Empty<DataPoint>(), await sut.ToArrayAsync());
             Assert.AreEqual(0, (await sut.ToListAsync()).Count);
         }


### PR DESCRIPTION
Fixes https://github.com/gfoidl/DataCompression/issues/45

## NoCompression

### Before

![grafik](https://user-images.githubusercontent.com/5755834/71170287-2668eb80-225b-11ea-9036-7ac38f376828.png)

### After

![grafik](https://user-images.githubusercontent.com/5755834/71170399-73e55880-225b-11ea-9c9e-8558688899e0.png)

## DeadBandCompression

### Before

![grafik](https://user-images.githubusercontent.com/5755834/71187497-7d80b780-227f-11ea-83cd-8f534e268f3f.png)

### After

TBD
![grafik](https://user-images.githubusercontent.com/5755834/71324366-452ae480-24de-11ea-8db9-efcfcaf85f73.png)

## SwingingDoorCompression

### Before

![grafik](https://user-images.githubusercontent.com/5755834/71187649-c46ead00-227f-11ea-8ff0-0bfdaaa966ae.png)

### After

TBD
![grafik](https://user-images.githubusercontent.com/5755834/71324376-6d1a4800-24de-11ea-9332-e973c2b05272.png)
