### PR TITLE
Task.Yield instead of Task.CompletedTask

### DIFF
--- a/perf/gfoidl.DataCompression.Benchmarks/Base.cs
+++ b/perf/gfoidl.DataCompression.Benchmarks/Base.cs
@@ -32,7 +32,7 @@ namespace gfoidl.DataCompression.Benchmarks
         {
             foreach (DataPoint dataPoint in this.Source())
             {
-                await Task.CompletedTask;
+                await Task.Yield();
                 yield return dataPoint;
             }
         }


### PR DESCRIPTION
Damned, in https://github.com/gfoidl/DataCompression/pull/50 I didn't think enough and merged to early. With `Task.CompletedTask` the async state machinery won't trigger, as the result is already completed. So use `Task.Yield` to force async.