### PR TITLE
Caching of DataPointIterator instances

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
     dotnet-executor:
         docker:
-            - image: mcr.microsoft.com/dotnet/core/sdk:3.1
+            - image: mcr.microsoft.com/dotnet/sdk:5.0
               environment:
                 DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
                 DOTNET_CLI_TELEMETRY_OPTOUT: 1

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,7 +15,7 @@
 
     <PropertyGroup>
         <LangVersion>latest</LangVersion>
-        <StandardTfms>netcoreapp3.1</StandardTfms>
+        <StandardTfms>net5.0</StandardTfms>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/demos/Directory.Build.props
+++ b/demos/Directory.Build.props
@@ -4,7 +4,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <StandardTfm>netcoreapp3.1</StandardTfm>
+        <StandardTfm>net5.0</StandardTfm>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 

--- a/gfoidl.DataCompression.sln
+++ b/gfoidl.DataCompression.sln
@@ -97,10 +97,15 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".circleci", ".circleci", "{
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "perf", "perf", "{CEFBCCE8-6F5E-483A-97D2-58907F7BCE24}"
+	ProjectSection(SolutionItems) = preProject
+		perf\Directory.Build.props = perf\Directory.Build.props
+	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "gfoidl.DataCompression.Benchmarks", "perf\gfoidl.DataCompression.Benchmarks\gfoidl.DataCompression.Benchmarks.csproj", "{81D55029-F85F-4624-BAA1-7128A6FA1A66}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "gfoidl.DataCompression.Benchmarks", "perf\gfoidl.DataCompression.Benchmarks\gfoidl.DataCompression.Benchmarks.csproj", "{81D55029-F85F-4624-BAA1-7128A6FA1A66}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "gfoidl.DataCompression.Demos.Async", "demos\gfoidl.DataCompression.Demos.Async\gfoidl.DataCompression.Demos.Async.csproj", "{9C0564C7-5902-40C1-9883-887BF7AC2187}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "gfoidl.DataCompression.Demos.Async", "demos\gfoidl.DataCompression.Demos.Async\gfoidl.DataCompression.Demos.Async.csproj", "{9C0564C7-5902-40C1-9883-887BF7AC2187}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "gfoidl.DataCompression.ProfilingDemo", "perf\gfoidl.DataCompression.ProfilingDemo\gfoidl.DataCompression.ProfilingDemo.csproj", "{09AB77CA-1C03-4C3B-96B7-9A05E0DDD4C9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -144,6 +149,10 @@ Global
 		{9C0564C7-5902-40C1-9883-887BF7AC2187}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9C0564C7-5902-40C1-9883-887BF7AC2187}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9C0564C7-5902-40C1-9883-887BF7AC2187}.Release|Any CPU.Build.0 = Release|Any CPU
+		{09AB77CA-1C03-4C3B-96B7-9A05E0DDD4C9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{09AB77CA-1C03-4C3B-96B7-9A05E0DDD4C9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{09AB77CA-1C03-4C3B-96B7-9A05E0DDD4C9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{09AB77CA-1C03-4C3B-96B7-9A05E0DDD4C9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -163,6 +172,7 @@ Global
 		{4461519B-5A2E-4B38-A93B-B561244C05C8} = {5EC3A886-352D-490B-90F0-F0EEA56C959F}
 		{81D55029-F85F-4624-BAA1-7128A6FA1A66} = {CEFBCCE8-6F5E-483A-97D2-58907F7BCE24}
 		{9C0564C7-5902-40C1-9883-887BF7AC2187} = {26C3FC5E-B8F2-4B7E-B264-7EC29772DC7C}
+		{09AB77CA-1C03-4C3B-96B7-9A05E0DDD4C9} = {CEFBCCE8-6F5E-483A-97D2-58907F7BCE24}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {BB4A29EA-001D-4E57-BBF5-C442F27797AE}

--- a/perf/Directory.Build.props
+++ b/perf/Directory.Build.props
@@ -5,6 +5,7 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <StandardTfm>netcoreapp3.1</StandardTfm>
+        <LangVersion>9</LangVersion>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 

--- a/perf/Directory.Build.props
+++ b/perf/Directory.Build.props
@@ -4,8 +4,8 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <StandardTfm>netcoreapp3.1</StandardTfm>
-        <LangVersion>9</LangVersion>
+        <StandardTfm>net5.0</StandardTfm>
+        <LangVersion>9.0</LangVersion>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 

--- a/perf/Directory.Build.props
+++ b/perf/Directory.Build.props
@@ -12,8 +12,4 @@
         <ProjectReference Include="..\..\source\gfoidl.DataCompression\gfoidl.DataCompression.csproj" />
     </ItemGroup>
 
-    <ItemGroup>
-        <Content Include="data\*" CopyToOutputDirectory="PreserveNewest" />
-    </ItemGroup>
-
 </Project>

--- a/perf/gfoidl.DataCompression.Benchmarks/Base.cs
+++ b/perf/gfoidl.DataCompression.Benchmarks/Base.cs
@@ -9,7 +9,7 @@ namespace gfoidl.DataCompression.Benchmarks
     public abstract class Base
     {
         private const int Count = 1_000_000;
-        private Random _rnd;
+        private Random? _rnd;
         //---------------------------------------------------------------------
         [GlobalSetup]
         public void GlobalSetup()
@@ -22,7 +22,7 @@ namespace gfoidl.DataCompression.Benchmarks
             for (int i = 0; i < Count; ++i)
             {
                 double x = i;
-                double y = _rnd.NextDouble();
+                double y = _rnd!.NextDouble();
 
                 yield return (x, y);
             }

--- a/perf/gfoidl.DataCompression.Benchmarks/Base.cs
+++ b/perf/gfoidl.DataCompression.Benchmarks/Base.cs
@@ -17,9 +17,9 @@ namespace gfoidl.DataCompression.Benchmarks
             _rnd = new Random(42);
         }
         //---------------------------------------------------------------------
-        protected IEnumerable<DataPoint> Source()
+        protected IEnumerable<DataPoint> Source(int count = Count)
         {
-            for (int i = 0; i < Count; ++i)
+            for (int i = 0; i < count; ++i)
             {
                 double x = i;
                 double y = _rnd!.NextDouble();
@@ -28,9 +28,9 @@ namespace gfoidl.DataCompression.Benchmarks
             }
         }
         //---------------------------------------------------------------------
-        protected async IAsyncEnumerable<DataPoint> SourceAsync()
+        protected async IAsyncEnumerable<DataPoint> SourceAsync(int count = Count)
         {
-            foreach (DataPoint dataPoint in this.Source())
+            foreach (DataPoint dataPoint in this.Source(count))
             {
                 await Task.Yield();
                 yield return dataPoint;

--- a/perf/gfoidl.DataCompression.Benchmarks/Infrastructure/CompressionFactories.cs
+++ b/perf/gfoidl.DataCompression.Benchmarks/Infrastructure/CompressionFactories.cs
@@ -1,0 +1,17 @@
+﻿namespace gfoidl.DataCompression.Benchmarks.Infrastructure
+{
+    public interface ICompressionFactory
+    {
+        ICompression Create();
+    }
+    //-------------------------------------------------------------------------
+    public class DeadBandCompressionFactory : ICompressionFactory
+    {
+        public ICompression Create() => new DataCompression.DeadBandCompression(0.1);
+    }
+    //-------------------------------------------------------------------------
+    public class SwingingDoorCompressionFactory : ICompressionFactory
+    {
+        public ICompression Create() => new DataCompression.SwingingDoorCompression(0.1);
+    }
+}

--- a/perf/gfoidl.DataCompression.Benchmarks/IteratorInstantiatonBenchmark.cs
+++ b/perf/gfoidl.DataCompression.Benchmarks/IteratorInstantiatonBenchmark.cs
@@ -1,0 +1,73 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using gfoidl.DataCompression.Benchmarks.Infrastructure;
+
+namespace gfoidl.DataCompression.Benchmarks
+{
+    [ShortRunJob]
+    [GenericTypeArguments(typeof(DeadBandCompressionFactory))]
+    [GenericTypeArguments(typeof(SwingingDoorCompressionFactory))]
+    public class IteratorInstantiatonBenchmark<TFactory> : Base where TFactory : ICompressionFactory, new()
+    {
+        private const int Count = 2;
+
+        private readonly DataPoint[]  _dataPoints = { new DataPoint((0, 1)), new DataPoint((1, 0)) };
+        private readonly ICompression _compression;
+        //---------------------------------------------------------------------
+        public IteratorInstantiatonBenchmark()
+        {
+            TFactory factory = new();
+            _compression     = factory.Create();
+        }
+        //---------------------------------------------------------------------
+        [Benchmark]
+        public double SingleIteration()
+        {
+            DataPointIterator iterator    = _compression.Process(_dataPoints);
+            return this.Consume(iterator);
+        }
+        //---------------------------------------------------------------------
+        //[Benchmark]
+        public async ValueTask<double> SingleIterationASync()
+        {
+            IAsyncEnumerable<DataPoint> source = this.SourceAsync(Count);
+            DataPointIterator iterator         = _compression.ProcessAsync(source);
+            return await this.ConsumeAsync(iterator);
+        }
+        //---------------------------------------------------------------------
+        [Benchmark]
+        [Arguments(100)]
+        [Arguments(1_000)]
+        public double MultipleIterations(int n)
+        {
+            double sum = 0;
+
+            for (int i = 0; i < n; ++i)
+            {
+                DataPointIterator iterator    = _compression.Process(_dataPoints);
+                sum += this.Consume(iterator);
+            }
+
+            return sum;
+        }
+        //---------------------------------------------------------------------
+        //[Benchmark]
+        [Arguments(100)]
+        [Arguments(1_000)]
+        public async ValueTask<double> MultipleIterationsAsync(int n)
+        {
+            double sum = 0;
+
+            for (int i = 0; i < n; ++i)
+            {
+                IAsyncEnumerable<DataPoint> source = this.SourceAsync(Count);
+                DataPointIterator iterator         = _compression.ProcessAsync(source);
+                sum += await this.ConsumeAsync(iterator);
+            }
+
+            return sum;
+        }
+    }
+}

--- a/perf/gfoidl.DataCompression.Benchmarks/Program.cs
+++ b/perf/gfoidl.DataCompression.Benchmarks/Program.cs
@@ -1,12 +1,4 @@
 ﻿using BenchmarkDotNet.Running;
+using gfoidl.DataCompression.Benchmarks;
 
-namespace gfoidl.DataCompression.Benchmarks
-{
-    class Program
-    {
-        static void Main(string[] args)
-        {
-            BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
-        }
-    }
-}
+BenchmarkSwitcher.FromAssembly(typeof(Base).Assembly).Run(args);

--- a/perf/gfoidl.DataCompression.Benchmarks/gfoidl.DataCompression.Benchmarks.csproj
+++ b/perf/gfoidl.DataCompression.Benchmarks/gfoidl.DataCompression.Benchmarks.csproj
@@ -1,16 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <OutputType>Exe</OutputType>
         <TargetFramework>$(StandardTfms)</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="BenchmarkDotNet" Version="0.12.0" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <ProjectReference Include="..\..\source\gfoidl.DataCompression\gfoidl.DataCompression.csproj" />
     </ItemGroup>
 
 </Project>

--- a/perf/gfoidl.DataCompression.Benchmarks/gfoidl.DataCompression.Benchmarks.csproj
+++ b/perf/gfoidl.DataCompression.Benchmarks/gfoidl.DataCompression.Benchmarks.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="BenchmarkDotNet" Version="0.12.0" />
+        <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
     </ItemGroup>
 
 </Project>

--- a/perf/gfoidl.DataCompression.ProfilingDemo/Program.cs
+++ b/perf/gfoidl.DataCompression.ProfilingDemo/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -41,7 +42,7 @@ namespace gfoidl.DataCompression.ProfilingDemo
                     //    //.DeadBandCompression(0.05)
                     //    .SwingingDoorCompression(0.1);
 
-                    DataPointIterator compressed = compression.Process(s_dataPoints);
+                    DataPointIterator compressed = compression.Process(s_dataPoints.Select(d => d));
 
                     foreach (DataPoint item in compressed)
                     {

--- a/perf/gfoidl.DataCompression.ProfilingDemo/Program.cs
+++ b/perf/gfoidl.DataCompression.ProfilingDemo/Program.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace gfoidl.DataCompression.ProfilingDemo
+{
+    static class Program
+    {
+        private static readonly DataPoint[] s_dataPoints;
+        private static List<DataPoint>      s_compressed = new List<DataPoint>(1000);
+        //---------------------------------------------------------------------
+        static Program()
+        {
+            Random rnd   = new Random();
+            s_dataPoints = new DataPoint[1000];
+
+            for (int i = 0; i < s_dataPoints.Length; ++i)
+            {
+                s_dataPoints[i] = new DataPoint(i, rnd.NextDouble());
+            }
+        }
+        //---------------------------------------------------------------------
+        static async Task Main()
+        {
+            using CancellationTokenSource cts = new CancellationTokenSource();
+            int counter = 0;
+
+            Task t = Task.Run(() =>
+            {
+                // A single instance can be re-used over and over again
+                SwingingDoorCompression compression = new SwingingDoorCompression(0.1);
+
+                while (!cts.IsCancellationRequested)
+                {
+                    s_compressed.Clear();
+                    counter++;
+
+                    // Allocates a new instance of compression each iteration
+                    //DataPointIterator compressed = s_dataPoints//.Select(d => d)
+                    //    //.DeadBandCompression(0.05)
+                    //    .SwingingDoorCompression(0.1);
+
+                    DataPointIterator compressed = compression.Process(s_dataPoints);
+
+                    foreach (DataPoint item in compressed)
+                    {
+                        s_compressed.Add(item);
+                    }
+
+                    Console.Write(".");
+                }
+            }, cts.Token);
+
+            Console.WriteLine("any key to stop...");
+            Console.ReadKey();
+
+            cts.Cancel();
+
+            try
+            {
+                await t;
+            }
+            catch (OperationCanceledException)
+            { }
+
+            Console.WriteLine($"\n\nend -- counter: {counter}");
+        }
+    }
+}

--- a/perf/gfoidl.DataCompression.ProfilingDemo/Program.cs
+++ b/perf/gfoidl.DataCompression.ProfilingDemo/Program.cs
@@ -30,7 +30,8 @@ namespace gfoidl.DataCompression.ProfilingDemo
             Task t = Task.Run(() =>
             {
                 // A single instance can be re-used over and over again
-                SwingingDoorCompression compression = new SwingingDoorCompression(0.1);
+                DeadBandCompression deadBand         = new DeadBandCompression(0.1);
+                SwingingDoorCompression swingingDoor = new SwingingDoorCompression(0.1);
 
                 while (!cts.IsCancellationRequested)
                 {
@@ -42,9 +43,11 @@ namespace gfoidl.DataCompression.ProfilingDemo
                     //    //.DeadBandCompression(0.05)
                     //    .SwingingDoorCompression(0.1);
 
-                    DataPointIterator compressed = compression.Process(s_dataPoints.Select(d => d));
+                    //DataPointIterator compressed = compression.Process(s_dataPoints.Select(d => d));
+                    DataPointIterator deadBandCompressed = deadBand.Process(s_dataPoints);
+                    DataPointIterator swingingDoorCompressed = swingingDoor.Process(deadBandCompressed);
 
-                    foreach (DataPoint item in compressed)
+                    foreach (DataPoint item in swingingDoorCompressed)
                     {
                         s_compressed.Add(item);
                     }

--- a/perf/gfoidl.DataCompression.ProfilingDemo/gfoidl.DataCompression.ProfilingDemo.csproj
+++ b/perf/gfoidl.DataCompression.ProfilingDemo/gfoidl.DataCompression.ProfilingDemo.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>$(StandardTfm)</TargetFramework>
+    </PropertyGroup>
+
+</Project>

--- a/source/gfoidl.DataCompression/Compression/DeadBandCompression/AsyncEnumerableIterator.cs
+++ b/source/gfoidl.DataCompression/Compression/DeadBandCompression/AsyncEnumerableIterator.cs
@@ -1,17 +1,31 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
 
 namespace gfoidl.DataCompression.Internal.DeadBand
 {
     internal sealed class AsyncEnumerableIterator : DeadBandCompressionIterator
     {
-        public AsyncEnumerableIterator(DeadBandCompression deadBandCompression, IAsyncEnumerable<DataPoint> source)
-            : base(deadBandCompression)
-            => _asyncSource = source;
+        public void SetData(DeadBandCompression deadBandCompression, IAsyncEnumerable<DataPoint> source)
+        {
+            this.SetData(deadBandCompression as Compression, source);
+            _deadBandCompression = deadBandCompression;
+        }
         //---------------------------------------------------------------------
         public override DataPointIterator Clone() => throw new NotSupportedException();
         public override bool MoveNext()           => throw new NotSupportedException();
         public override DataPoint[] ToArray()     => throw new NotSupportedException();
         public override List<DataPoint> ToList()  => throw new NotSupportedException();
+        //---------------------------------------------------------------------
+        protected override void DisposeCore()
+        {
+            Debug.Assert(_deadBandCompression is not null);
+
+            ref AsyncEnumerableIterator? cache = ref _deadBandCompression._cachedAsyncEnumerableIterator;
+            Interlocked.CompareExchange(ref cache, this, null);
+
+            base.DisposeCore();
+        }
     }
 }

--- a/source/gfoidl.DataCompression/Compression/DeadBandCompression/DeadBandCompression.cs
+++ b/source/gfoidl.DataCompression/Compression/DeadBandCompression/DeadBandCompression.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using gfoidl.DataCompression.Internal.DeadBand;
 using gfoidl.DataCompression.Wrappers;
 
@@ -13,6 +14,12 @@ namespace gfoidl.DataCompression
     /// </remarks>
     public class DeadBandCompression : Compression
     {
+#if NETSTANDARD2_1
+        internal AsyncEnumerableIterator?      _cachedAsyncEnumerableIterator;
+#endif
+        internal DataPointIterator?            _cachedIndexedIterator;       // due to generics use base class
+        internal SequentialEnumerableIterator? _cachedSequentialEnumerableIterator;
+        //---------------------------------------------------------------------
         /// <summary>
         /// (Absolut) precision of the instrument.
         /// </summary>
@@ -50,59 +57,106 @@ namespace gfoidl.DataCompression
             : this(instrumentPrecision, maxTime.Ticks, minTime?.Ticks)
         { }
         //---------------------------------------------------------------------
-        /// <summary>
-        /// Implementation of the compression / filtering.
-        /// </summary>
-        /// <param name="data">Input data</param>
-        /// <returns>The compressed / filtered data.</returns>
+        /// <inheritdoc />
         protected override DataPointIterator ProcessCore(IEnumerable<DataPoint> data)
         {
             if (data is ArrayWrapper<DataPoint> arrayWrapper)
             {
-                return arrayWrapper.Count == 0
-                    ? DataPointIterator.Empty
-                    : new IndexedIterator<ArrayWrapper<DataPoint>>(this, arrayWrapper);
+                if (arrayWrapper.Count == 0) return DataPointIterator.Empty;
+
+                DataPointIterator? cached = Interlocked.Exchange(ref _cachedIndexedIterator, null);
+
+                if (cached is not IndexedIterator<ArrayWrapper<DataPoint>> iter)
+                {
+                    Interlocked.CompareExchange(ref _cachedIndexedIterator, cached, null);
+                    iter = new IndexedIterator<ArrayWrapper<DataPoint>>();
+                }
+
+                iter.SetData(this, arrayWrapper);
+                return iter;
             }
 
             if (data is ListWrapper<DataPoint> listWrapper)
             {
-                return listWrapper.Count == 0
-                    ? DataPointIterator.Empty
-                    : new IndexedIterator<ListWrapper<DataPoint>>(this, listWrapper);
+                if (listWrapper.Count == 0) return DataPointIterator.Empty;
+
+                DataPointIterator? cached = Interlocked.Exchange(ref _cachedIndexedIterator, null);
+
+                if (cached is not IndexedIterator<ListWrapper<DataPoint>> iter)
+                {
+                    Interlocked.CompareExchange(ref _cachedIndexedIterator, cached, null);
+                    iter = new IndexedIterator<ListWrapper<DataPoint>>();
+                }
+
+                iter.SetData(this, listWrapper);
+                return iter;
             }
 
             if (data is DataPoint[] array)
             {
-                return array.Length == 0
-                    ? DataPointIterator.Empty
-                    : new IndexedIterator<ArrayWrapper<DataPoint>>(this, new ArrayWrapper<DataPoint>(array));
+                if (array.Length == 0) return DataPointIterator.Empty;
+
+                DataPointIterator? cached = Interlocked.Exchange(ref _cachedIndexedIterator, null);
+
+                if (cached is not IndexedIterator<ArrayWrapper<DataPoint>> iter)
+                {
+                    Interlocked.CompareExchange(ref _cachedIndexedIterator, cached, null);
+                    iter = new IndexedIterator<ArrayWrapper<DataPoint>>();
+                }
+
+                iter.SetData(this, new ArrayWrapper<DataPoint>(array));
+                return iter;
             }
 
             if (data is List<DataPoint> list)
             {
-                return list.Count == 0
-                    ? DataPointIterator.Empty
-                    : new IndexedIterator<ListWrapper<DataPoint>>(this, new ListWrapper<DataPoint>(list));
+                if (list.Count == 0) return DataPointIterator.Empty;
+
+                DataPointIterator? cached = Interlocked.Exchange(ref _cachedIndexedIterator, null);
+
+                if (cached is not IndexedIterator<ListWrapper<DataPoint>> iter)
+                {
+                    Interlocked.CompareExchange(ref _cachedIndexedIterator, cached, null);
+                    iter = new IndexedIterator<ListWrapper<DataPoint>>();
+                }
+
+                iter.SetData(this, new ListWrapper<DataPoint>(list));
+                return iter;
             }
 
             if (data is IList<DataPoint> ilist)
             {
-                return ilist.Count == 0
-                    ? DataPointIterator.Empty
-                    : new IndexedIterator<IList<DataPoint>>(this, ilist);
+                if (ilist.Count == 0) return DataPointIterator.Empty;
+
+                DataPointIterator? cached = Interlocked.Exchange(ref _cachedIndexedIterator, null);
+
+                if (cached is not IndexedIterator<IList<DataPoint>> iter)
+                {
+                    Interlocked.CompareExchange(ref _cachedIndexedIterator, cached, null);
+                    iter = new IndexedIterator<IList<DataPoint>>();
+                }
+
+                iter.SetData(this, ilist);
+                return iter;
             }
 
-            return new SequentialEnumerableIterator(this, data);
+            SequentialEnumerableIterator seqIter = Interlocked.Exchange(ref _cachedSequentialEnumerableIterator, null)
+                ?? new SequentialEnumerableIterator();
+
+            seqIter.SetData(this, data);
+            return seqIter;
         }
         //---------------------------------------------------------------------
 #if NETSTANDARD2_1
-        /// <summary>
-        /// Implementation of the compression / filtering.
-        /// </summary>
-        /// <param name="data">Input data</param>
-        /// <returns>The compressed / filtered data.</returns>
+        /// <inheritdoc />
         protected override DataPointIterator ProcessAsyncCore(IAsyncEnumerable<DataPoint> data)
-            => new AsyncEnumerableIterator(this, data);
+        {
+            AsyncEnumerableIterator iter = Interlocked.Exchange(ref _cachedAsyncEnumerableIterator, null)
+                ?? new AsyncEnumerableIterator();
+
+            iter.SetData(this, data);
+            return iter;
+        }
 #endif
     }
 }

--- a/source/gfoidl.DataCompression/Compression/DeadBandCompression/DeadBandCompression.cs
+++ b/source/gfoidl.DataCompression/Compression/DeadBandCompression/DeadBandCompression.cs
@@ -17,8 +17,8 @@ namespace gfoidl.DataCompression
 #if NETSTANDARD2_1
         internal AsyncEnumerableIterator?      _cachedAsyncEnumerableIterator;
 #endif
-        internal DataPointIterator?            _cachedIndexedIterator;       // due to generics use base class
         internal SequentialEnumerableIterator? _cachedSequentialEnumerableIterator;
+        internal DataPointIterator?            _cachedIndexedIterator;       // due to generics use base class
         //---------------------------------------------------------------------
         /// <summary>
         /// (Absolut) precision of the instrument.

--- a/source/gfoidl.DataCompression/Compression/DeadBandCompression/DeadBandCompressionIterator.cs
+++ b/source/gfoidl.DataCompression/Compression/DeadBandCompression/DeadBandCompressionIterator.cs
@@ -9,10 +9,6 @@ namespace gfoidl.DataCompression.Internal.DeadBand
         protected DeadBandCompression?     _deadBandCompression;
         protected (double Min, double Max) _bounding;
         //---------------------------------------------------------------------
-        protected DeadBandCompressionIterator(DeadBandCompression deadBandCompression)
-            : base(deadBandCompression)
-            => _deadBandCompression = deadBandCompression;
-        //---------------------------------------------------------------------
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void GetBounding(in DataPoint dataPoint)
         {
@@ -52,12 +48,12 @@ namespace gfoidl.DataCompression.Internal.DeadBand
         protected internal override void Init(in DataPoint incoming, ref DataPoint snapShot)                   => this.UpdatePoints(incoming, ref snapShot);
         protected internal override void Init(int incomingIndex, in DataPoint incoming, ref int snapShotIndex) => throw new NotSupportedException();
         //---------------------------------------------------------------------
-        protected override void ResetToInitialState()
+        protected override void DisposeCore()
         {
-            base.ResetToInitialState();
-
             _deadBandCompression = null;
             _bounding            = default;
+
+            base.DisposeCore();
         }
     }
 }

--- a/source/gfoidl.DataCompression/Compression/DeadBandCompression/DeadBandCompressionIterator.cs
+++ b/source/gfoidl.DataCompression/Compression/DeadBandCompression/DeadBandCompressionIterator.cs
@@ -1,12 +1,13 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
 namespace gfoidl.DataCompression.Internal.DeadBand
 {
     internal abstract class DeadBandCompressionIterator : DataPointIterator
     {
-        protected readonly DeadBandCompression _deadBandCompression;
-        protected (double Min, double Max)     _bounding;
+        protected DeadBandCompression?     _deadBandCompression;
+        protected (double Min, double Max) _bounding;
         //---------------------------------------------------------------------
         protected DeadBandCompressionIterator(DeadBandCompression deadBandCompression)
             : base(deadBandCompression)
@@ -15,6 +16,8 @@ namespace gfoidl.DataCompression.Internal.DeadBand
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void GetBounding(in DataPoint dataPoint)
         {
+            Debug.Assert(_deadBandCompression is not null);
+
             double y = dataPoint.Y;
 
             // Produces better code than updating _bounding directly
@@ -48,5 +51,13 @@ namespace gfoidl.DataCompression.Internal.DeadBand
         //---------------------------------------------------------------------
         protected internal override void Init(in DataPoint incoming, ref DataPoint snapShot)                   => this.UpdatePoints(incoming, ref snapShot);
         protected internal override void Init(int incomingIndex, in DataPoint incoming, ref int snapShotIndex) => throw new NotSupportedException();
+        //---------------------------------------------------------------------
+        protected override void ResetToInitialState()
+        {
+            base.ResetToInitialState();
+
+            _deadBandCompression = null;
+            _bounding            = default;
+        }
     }
 }

--- a/source/gfoidl.DataCompression/Compression/DeadBandCompression/IndexedIterator.cs
+++ b/source/gfoidl.DataCompression/Compression/DeadBandCompression/IndexedIterator.cs
@@ -9,8 +9,8 @@ namespace gfoidl.DataCompression.Internal.DeadBand
     internal sealed class IndexedIterator<TList> : DeadBandCompressionIterator
         where TList : IList<DataPoint>
     {
-        private readonly TList                           _list;
-        private readonly DataPointIndexedIterator<TList> _inner;
+        private TList?                           _list;
+        private DataPointIndexedIterator<TList>? _inner;
         //---------------------------------------------------------------------
         public IndexedIterator(DeadBandCompression deadBandCompression, TList source)
             : base(deadBandCompression)
@@ -19,16 +19,16 @@ namespace gfoidl.DataCompression.Internal.DeadBand
             _inner = new DataPointIndexedIterator<TList>(deadBandCompression, this, source);
         }
         //---------------------------------------------------------------------
-        public override DataPointIterator Clone()         => new IndexedIterator<TList>(_deadBandCompression, _list);
-        public override DataPointIterator GetEnumerator() => _inner.GetEnumerator();
-        public override DataPoint[] ToArray()             => _inner.ToArray();
-        public override List<DataPoint> ToList()          => _inner.ToList();
+        public override DataPointIterator Clone()         => new IndexedIterator<TList>(_deadBandCompression!, _list!);
+        public override DataPointIterator GetEnumerator() => _inner!.GetEnumerator();
+        public override DataPoint[] ToArray()             => _inner!.ToArray();
+        public override List<DataPoint> ToList()          => _inner!.ToList();
         public override bool MoveNext()                   => throw new InvalidOperationException("Should operate on _inner");
         //---------------------------------------------------------------------
         public override void Dispose()
         {
-            base.Dispose();
-            _inner.Dispose();
+            base   .Dispose();
+            _inner?.Dispose();
         }
         //---------------------------------------------------------------------
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -46,5 +46,13 @@ namespace gfoidl.DataCompression.Internal.DeadBand
         public override ValueTask<DataPoint[]> ToArrayAsync(CancellationToken ct)    => throw new NotSupportedException();
         public override ValueTask<List<DataPoint>> ToListAsync(CancellationToken ct) => throw new NotSupportedException();
 #endif
+        //---------------------------------------------------------------------
+        protected override void ResetToInitialState()
+        {
+            base.ResetToInitialState();
+
+            _list  = default;
+            _inner = null;
+        }
     }
 }

--- a/source/gfoidl.DataCompression/Compression/DeadBandCompression/SequentialEnumerableIterator.cs
+++ b/source/gfoidl.DataCompression/Compression/DeadBandCompression/SequentialEnumerableIterator.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -7,18 +8,36 @@ namespace gfoidl.DataCompression.Internal.DeadBand
 {
     internal sealed class SequentialEnumerableIterator : DeadBandCompressionIterator
     {
-        public SequentialEnumerableIterator(DeadBandCompression deadBandCompression, IEnumerable<DataPoint>? source)
-            : base(deadBandCompression)
+        public void SetData(DeadBandCompression deadBandCompression, IEnumerable<DataPoint> source)
         {
-            _source     = source ?? throw new ArgumentNullException(nameof(source));
-            _enumerator = source.GetEnumerator();
+            this.SetData(deadBandCompression as Compression, source);
+            _deadBandCompression = deadBandCompression;
         }
         //---------------------------------------------------------------------
-        public override DataPointIterator Clone() => new SequentialEnumerableIterator(_deadBandCompression!, _source);
+        public override DataPointIterator Clone()
+        {
+            Debug.Assert(_deadBandCompression is not null);
+            Debug.Assert(_source              is not null);
+
+            SequentialEnumerableIterator clone = new();
+            clone.SetData(_deadBandCompression, _source);
+
+            return clone;
+        }
         //---------------------------------------------------------------------
 #if NETSTANDARD2_1
         public override ValueTask<DataPoint[]> ToArrayAsync(CancellationToken ct)    => throw new NotSupportedException();
         public override ValueTask<List<DataPoint>> ToListAsync(CancellationToken ct) => throw new NotSupportedException();
 #endif
+        //---------------------------------------------------------------------
+        protected override void DisposeCore()
+        {
+            Debug.Assert(_deadBandCompression is not null);
+
+            ref SequentialEnumerableIterator? cache = ref _deadBandCompression._cachedSequentialEnumerableIterator;
+            Interlocked.CompareExchange(ref cache, this, null);
+
+            base.DisposeCore();
+        }
     }
 }

--- a/source/gfoidl.DataCompression/Compression/DeadBandCompression/SequentialEnumerableIterator.cs
+++ b/source/gfoidl.DataCompression/Compression/DeadBandCompression/SequentialEnumerableIterator.cs
@@ -14,7 +14,7 @@ namespace gfoidl.DataCompression.Internal.DeadBand
             _enumerator = source.GetEnumerator();
         }
         //---------------------------------------------------------------------
-        public override DataPointIterator Clone() => new SequentialEnumerableIterator(_deadBandCompression, _source);
+        public override DataPointIterator Clone() => new SequentialEnumerableIterator(_deadBandCompression!, _source);
         //---------------------------------------------------------------------
 #if NETSTANDARD2_1
         public override ValueTask<DataPoint[]> ToArrayAsync(CancellationToken ct)    => throw new NotSupportedException();

--- a/source/gfoidl.DataCompression/Compression/NoCompression/AsyncEnumerableIterator.cs
+++ b/source/gfoidl.DataCompression/Compression/NoCompression/AsyncEnumerableIterator.cs
@@ -3,16 +3,11 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
-using gfoidl.DataCompression.Builders;
 
 namespace gfoidl.DataCompression.Internal.NoCompression
 {
     internal sealed class AsyncEnumerableIterator : NoCompressionIterator
     {
-        public AsyncEnumerableIterator(Compression compression, IAsyncEnumerable<DataPoint> enumerable)
-            : base(compression)
-            => _asyncSource = enumerable;
-        //---------------------------------------------------------------------
         public override IAsyncEnumerator<DataPoint> GetAsyncEnumerator(CancellationToken cancellationToken = default)
             => this.IterateCore(cancellationToken);
         //---------------------------------------------------------------------

--- a/source/gfoidl.DataCompression/Compression/NoCompression/EnumerableIterator.cs
+++ b/source/gfoidl.DataCompression/Compression/NoCompression/EnumerableIterator.cs
@@ -16,7 +16,12 @@ namespace gfoidl.DataCompression.Internal.NoCompression
             _enumerator = enumerable.GetEnumerator();
         }
         //---------------------------------------------------------------------
-        public override DataPointIterator Clone() => new EnumerableIterator(_algorithm, _source);
+        public override DataPointIterator Clone()
+        {
+            Debug.Assert(_algorithm is not null);
+
+            return new EnumerableIterator(_algorithm, _source);
+        }
         //---------------------------------------------------------------------
         public override bool MoveNext()
         {

--- a/source/gfoidl.DataCompression/Compression/NoCompression/EnumerableIterator.cs
+++ b/source/gfoidl.DataCompression/Compression/NoCompression/EnumerableIterator.cs
@@ -9,18 +9,15 @@ namespace gfoidl.DataCompression.Internal.NoCompression
 {
     internal sealed class EnumerableIterator : NoCompressionIterator
     {
-        public EnumerableIterator(Compression compression, IEnumerable<DataPoint>? enumerable)
-            : base(compression)
-        {
-            _source     = enumerable ?? throw new ArgumentNullException(nameof(enumerable));
-            _enumerator = enumerable.GetEnumerator();
-        }
-        //---------------------------------------------------------------------
         public override DataPointIterator Clone()
         {
             Debug.Assert(_algorithm is not null);
+            Debug.Assert(_source    is not null);
 
-            return new EnumerableIterator(_algorithm, _source);
+            EnumerableIterator clone = new();
+            clone.SetData(_algorithm, _source);
+
+            return clone;
         }
         //---------------------------------------------------------------------
         public override bool MoveNext()

--- a/source/gfoidl.DataCompression/Compression/NoCompression/NoCompression.cs
+++ b/source/gfoidl.DataCompression/Compression/NoCompression/NoCompression.cs
@@ -16,7 +16,12 @@ namespace gfoidl.DataCompression
         /// <param name="data">Input data</param>
         /// <returns>The compressed / filtered data.</returns>
         protected override DataPointIterator ProcessCore(IEnumerable<DataPoint> data)
-            => new EnumerableIterator(this, data);
+        {
+            EnumerableIterator iter = new();
+            iter.SetData(this, data);
+
+            return iter;
+        }
         //---------------------------------------------------------------------
 #if NETSTANDARD2_1
         /// <summary>
@@ -25,7 +30,12 @@ namespace gfoidl.DataCompression
         /// <param name="data">Input data</param>
         /// <returns>The compressed / filtered data.</returns>
         protected override DataPointIterator ProcessAsyncCore(IAsyncEnumerable<DataPoint> data)
-            => new AsyncEnumerableIterator(this, data);
+        {
+            AsyncEnumerableIterator iter = new();
+            iter.SetData(this, data);
+
+            return iter;
+        }
 #endif
     }
 }

--- a/source/gfoidl.DataCompression/Compression/NoCompression/NoCompressionIterator.cs
+++ b/source/gfoidl.DataCompression/Compression/NoCompression/NoCompressionIterator.cs
@@ -1,9 +1,5 @@
 ﻿namespace gfoidl.DataCompression.Internal.NoCompression
 {
     internal abstract class NoCompressionIterator : DataPointIterator
-    {
-        protected NoCompressionIterator(Compression compression)
-            : base(compression)
-        { }
-    }
+    { }
 }

--- a/source/gfoidl.DataCompression/Compression/SwingingDoorCompression/AsyncEnumerableIterator.cs
+++ b/source/gfoidl.DataCompression/Compression/SwingingDoorCompression/AsyncEnumerableIterator.cs
@@ -1,17 +1,31 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
 
 namespace gfoidl.DataCompression.Internal.SwingingDoor
 {
     internal sealed class AsyncEnumerableIterator : SwingingDoorCompressionIterator
     {
-        public AsyncEnumerableIterator(SwingingDoorCompression swingingDoorCompression, IAsyncEnumerable<DataPoint> source)
-            : base(swingingDoorCompression)
-            => _asyncSource = source;
+        public void SetData(SwingingDoorCompression swingingDoorCompression, IAsyncEnumerable<DataPoint> source)
+        {
+            this.SetData(swingingDoorCompression as Compression, source);
+            _swingingDoorCompression = swingingDoorCompression;
+        }
         //---------------------------------------------------------------------
         public override DataPointIterator Clone() => throw new NotSupportedException();
         public override bool MoveNext()           => throw new NotSupportedException();
         public override DataPoint[] ToArray()     => throw new NotSupportedException();
         public override List<DataPoint> ToList()  => throw new NotSupportedException();
+        //---------------------------------------------------------------------
+        protected override void DisposeCore()
+        {
+            Debug.Assert(_swingingDoorCompression is not null);
+
+            ref AsyncEnumerableIterator? cache = ref _swingingDoorCompression._cachedAsyncEnumerableIterator;
+            Interlocked.CompareExchange(ref cache, this, null);
+
+            base.DisposeCore();
+        }
     }
 }

--- a/source/gfoidl.DataCompression/Compression/SwingingDoorCompression/IndexedIterator.cs
+++ b/source/gfoidl.DataCompression/Compression/SwingingDoorCompression/IndexedIterator.cs
@@ -9,8 +9,8 @@ namespace gfoidl.DataCompression.Internal.SwingingDoor
     internal sealed class IndexedIterator<TList> : SwingingDoorCompressionIterator
         where TList : IList<DataPoint>
     {
-        private readonly TList                           _list;
-        private readonly DataPointIndexedIterator<TList> _inner;
+        private TList?                           _list;
+        private DataPointIndexedIterator<TList>? _inner;
         //---------------------------------------------------------------------
         public IndexedIterator(SwingingDoorCompression swingingDoorCompression, TList source)
             : base(swingingDoorCompression)
@@ -19,16 +19,16 @@ namespace gfoidl.DataCompression.Internal.SwingingDoor
             _inner = new DataPointIndexedIterator<TList>(swingingDoorCompression, this, source);
         }
         //---------------------------------------------------------------------
-        public override DataPointIterator Clone()         => new IndexedIterator<TList>(_swingingDoorCompression, _list);
-        public override DataPointIterator GetEnumerator() => _inner.GetEnumerator();
-        public override DataPoint[] ToArray()             => _inner.ToArray();
-        public override List<DataPoint> ToList()          => _inner.ToList();
+        public override DataPointIterator Clone()         => new IndexedIterator<TList>(_swingingDoorCompression!, _list!);
+        public override DataPointIterator GetEnumerator() => _inner!.GetEnumerator();
+        public override DataPoint[] ToArray()             => _inner!.ToArray();
+        public override List<DataPoint> ToList()          => _inner!.ToList();
         public override bool MoveNext()                   => throw new InvalidOperationException("Should operate on _inner");
         //---------------------------------------------------------------------
         public override void Dispose()
         {
             base.Dispose();
-            _inner.Dispose();
+            _inner?.Dispose();
         }
         //---------------------------------------------------------------------
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -46,5 +46,13 @@ namespace gfoidl.DataCompression.Internal.SwingingDoor
         public override ValueTask<DataPoint[]> ToArrayAsync(CancellationToken ct)    => throw new NotSupportedException();
         public override ValueTask<List<DataPoint>> ToListAsync(CancellationToken ct) => throw new NotSupportedException();
 #endif
+        //---------------------------------------------------------------------
+        protected override void ResetToInitialState()
+        {
+            base.ResetToInitialState();
+
+            _list  = default;
+            _inner = null;
+        }
     }
 }

--- a/source/gfoidl.DataCompression/Compression/SwingingDoorCompression/SequentialEnumerableIterator.cs
+++ b/source/gfoidl.DataCompression/Compression/SwingingDoorCompression/SequentialEnumerableIterator.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -7,18 +8,36 @@ namespace gfoidl.DataCompression.Internal.SwingingDoor
 {
     internal sealed class SequentialEnumerableIterator : SwingingDoorCompressionIterator
     {
-        public SequentialEnumerableIterator(SwingingDoorCompression swingingDoorCompression, IEnumerable<DataPoint>? source)
-            : base(swingingDoorCompression)
+        public void SetData(SwingingDoorCompression swingingDoorCompression, IEnumerable<DataPoint> source)
         {
-            _source     = source ?? throw new ArgumentNullException(nameof(source));
-            _enumerator = source.GetEnumerator();
+            this.SetData(swingingDoorCompression as Compression, source);
+            _swingingDoorCompression = swingingDoorCompression;
         }
         //---------------------------------------------------------------------
-        public override DataPointIterator Clone() => new SequentialEnumerableIterator(_swingingDoorCompression!, _source);
+        public override DataPointIterator Clone()
+        {
+            Debug.Assert(_swingingDoorCompression is not null);
+            Debug.Assert(_source                  is not null);
+
+            SequentialEnumerableIterator clone = new();
+            clone.SetData(_swingingDoorCompression, _source);
+
+            return clone;
+        }
         //---------------------------------------------------------------------
 #if NETSTANDARD2_1
         public override ValueTask<DataPoint[]> ToArrayAsync(CancellationToken ct)    => throw new NotSupportedException();
         public override ValueTask<List<DataPoint>> ToListAsync(CancellationToken ct) => throw new NotSupportedException();
 #endif
+        //---------------------------------------------------------------------
+        protected override void DisposeCore()
+        {
+            Debug.Assert(_swingingDoorCompression is not null);
+
+            ref SequentialEnumerableIterator? cache = ref _swingingDoorCompression._cachedSequentialEnumerableIterator;
+            Interlocked.CompareExchange(ref cache, this, null);
+
+            base.DisposeCore();
+        }
     }
 }

--- a/source/gfoidl.DataCompression/Compression/SwingingDoorCompression/SequentialEnumerableIterator.cs
+++ b/source/gfoidl.DataCompression/Compression/SwingingDoorCompression/SequentialEnumerableIterator.cs
@@ -14,7 +14,7 @@ namespace gfoidl.DataCompression.Internal.SwingingDoor
             _enumerator = source.GetEnumerator();
         }
         //---------------------------------------------------------------------
-        public override DataPointIterator Clone() => new SequentialEnumerableIterator(_swingingDoorCompression, _source);
+        public override DataPointIterator Clone() => new SequentialEnumerableIterator(_swingingDoorCompression!, _source);
         //---------------------------------------------------------------------
 #if NETSTANDARD2_1
         public override ValueTask<DataPoint[]> ToArrayAsync(CancellationToken ct)    => throw new NotSupportedException();

--- a/source/gfoidl.DataCompression/Compression/SwingingDoorCompression/SwingingDoorCompression.cs
+++ b/source/gfoidl.DataCompression/Compression/SwingingDoorCompression/SwingingDoorCompression.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using gfoidl.DataCompression.Internal.SwingingDoor;
 using gfoidl.DataCompression.Wrappers;
 
@@ -13,6 +14,12 @@ namespace gfoidl.DataCompression
     /// </remarks>
     public class SwingingDoorCompression : Compression
     {
+#if NETSTANDARD2_1
+        internal AsyncEnumerableIterator?      _cachedAsyncEnumerableIterator;
+#endif
+        internal DataPointIterator?            _cachedIndexedIterator;       // due to generics use base class
+        internal SequentialEnumerableIterator? _cachedSequentialEnumerableIterator;
+        //---------------------------------------------------------------------
         /// <summary>
         /// (Absolut) Compression deviation applied to the y values to calculate the
         /// min and max slopes.
@@ -53,59 +60,106 @@ namespace gfoidl.DataCompression
             : this(compressionDeviation, maxTime.Ticks, minTime?.Ticks)
         { }
         //---------------------------------------------------------------------
-        /// <summary>
-        /// Implementation of the compression / filtering.
-        /// </summary>
-        /// <param name="data">Input data</param>
-        /// <returns>The compressed / filtered data.</returns>
+        /// <inheritdoc />
         protected override DataPointIterator ProcessCore(IEnumerable<DataPoint> data)
         {
             if (data is ArrayWrapper<DataPoint> arrayWrapper)
             {
-                return arrayWrapper.Count == 0
-                    ? DataPointIterator.Empty
-                    : new IndexedIterator<ArrayWrapper<DataPoint>>(this, arrayWrapper);
+                if (arrayWrapper.Count == 0) return DataPointIterator.Empty;
+
+                DataPointIterator? cached = Interlocked.Exchange(ref _cachedIndexedIterator, null);
+
+                if (cached is not IndexedIterator<ArrayWrapper<DataPoint>> iter)
+                {
+                    Interlocked.CompareExchange(ref _cachedIndexedIterator, cached, null);
+                    iter = new IndexedIterator<ArrayWrapper<DataPoint>>();
+                }
+
+                iter.SetData(this, arrayWrapper);
+                return iter;
             }
 
             if (data is ListWrapper<DataPoint> listWrapper)
             {
-                return listWrapper.Count == 0
-                    ? DataPointIterator.Empty
-                    : new IndexedIterator<ListWrapper<DataPoint>>(this, listWrapper);
+                if (listWrapper.Count == 0) return DataPointIterator.Empty;
+
+                DataPointIterator? cached = Interlocked.Exchange(ref _cachedIndexedIterator, null);
+
+                if (cached is not IndexedIterator<ListWrapper<DataPoint>> iter)
+                {
+                    Interlocked.CompareExchange(ref _cachedIndexedIterator, cached, null);
+                    iter = new IndexedIterator<ListWrapper<DataPoint>>();
+                }
+
+                iter.SetData(this, listWrapper);
+                return iter;
             }
 
             if (data is DataPoint[] array)
             {
-                return array.Length == 0
-                    ? DataPointIterator.Empty
-                    : new IndexedIterator<ArrayWrapper<DataPoint>>(this, new ArrayWrapper<DataPoint>(array));
+                if (array.Length == 0) return DataPointIterator.Empty;
+
+                DataPointIterator? cached = Interlocked.Exchange(ref _cachedIndexedIterator, null);
+
+                if (cached is not IndexedIterator<ArrayWrapper<DataPoint>> iter)
+                {
+                    Interlocked.CompareExchange(ref _cachedIndexedIterator, cached, null);
+                    iter = new IndexedIterator<ArrayWrapper<DataPoint>>();
+                }
+
+                iter.SetData(this, new ArrayWrapper<DataPoint>(array));
+                return iter;
             }
 
             if (data is List<DataPoint> list)
             {
-                return list.Count == 0
-                    ? DataPointIterator.Empty
-                    : new IndexedIterator<ListWrapper<DataPoint>>(this, new ListWrapper<DataPoint>(list));
+                if (list.Count == 0) return DataPointIterator.Empty;
+
+                DataPointIterator? cached = Interlocked.Exchange(ref _cachedIndexedIterator, null);
+
+                if (cached is not IndexedIterator<ListWrapper<DataPoint>> iter)
+                {
+                    Interlocked.CompareExchange(ref _cachedIndexedIterator, cached, null);
+                    iter = new IndexedIterator<ListWrapper<DataPoint>>();
+                }
+
+                iter.SetData(this, new ListWrapper<DataPoint>(list));
+                return iter;
             }
 
             if (data is IList<DataPoint> ilist)
             {
-                return ilist.Count == 0
-                    ? DataPointIterator.Empty
-                    : new IndexedIterator<IList<DataPoint>>(this, ilist);
+                if (ilist.Count == 0) return DataPointIterator.Empty;
+
+                DataPointIterator? cached = Interlocked.Exchange(ref _cachedIndexedIterator, null);
+
+                if (cached is not IndexedIterator<IList<DataPoint>> iter)
+                {
+                    Interlocked.CompareExchange(ref _cachedIndexedIterator, cached, null);
+                    iter = new IndexedIterator<IList<DataPoint>>();
+                }
+
+                iter.SetData(this, ilist);
+                return iter;
             }
 
-            return new SequentialEnumerableIterator(this, data);
+            SequentialEnumerableIterator seqIter = Interlocked.Exchange(ref _cachedSequentialEnumerableIterator, null)
+                ?? new SequentialEnumerableIterator();
+
+            seqIter.SetData(this, data);
+            return seqIter;
         }
         //---------------------------------------------------------------------
 #if NETSTANDARD2_1
-        /// <summary>
-        /// Implementation of the compression / filtering.
-        /// </summary>
-        /// <param name="data">Input data</param>
-        /// <returns>The compressed / filtered data.</returns>
+        /// <inheritdoc />
         protected override DataPointIterator ProcessAsyncCore(IAsyncEnumerable<DataPoint> data)
-            => new AsyncEnumerableIterator(this, data);
+        {
+            AsyncEnumerableIterator iter = Interlocked.Exchange(ref _cachedAsyncEnumerableIterator, null)
+                ?? new AsyncEnumerableIterator();
+
+            iter.SetData(this, data);
+            return iter;
+        }
 #endif
     }
 }

--- a/source/gfoidl.DataCompression/Compression/SwingingDoorCompression/SwingingDoorCompression.cs
+++ b/source/gfoidl.DataCompression/Compression/SwingingDoorCompression/SwingingDoorCompression.cs
@@ -17,8 +17,8 @@ namespace gfoidl.DataCompression
 #if NETSTANDARD2_1
         internal AsyncEnumerableIterator?      _cachedAsyncEnumerableIterator;
 #endif
-        internal DataPointIterator?            _cachedIndexedIterator;       // due to generics use base class
         internal SequentialEnumerableIterator? _cachedSequentialEnumerableIterator;
+        internal DataPointIterator?            _cachedIndexedIterator;       // due to generics use base class
         //---------------------------------------------------------------------
         /// <summary>
         /// (Absolut) Compression deviation applied to the y values to calculate the

--- a/source/gfoidl.DataCompression/Compression/SwingingDoorCompression/SwingingDoorCompressionIterator.cs
+++ b/source/gfoidl.DataCompression/Compression/SwingingDoorCompression/SwingingDoorCompressionIterator.cs
@@ -11,10 +11,6 @@ namespace gfoidl.DataCompression.Internal.SwingingDoor
         protected SwingingDoorCompression? _swingingDoorCompression;
         protected (double Max, double Min) _slope;
         //---------------------------------------------------------------------
-        protected SwingingDoorCompressionIterator(SwingingDoorCompression swingingDoorCompression)
-            : base(swingingDoorCompression)
-            => _swingingDoorCompression = swingingDoorCompression;
-        //---------------------------------------------------------------------
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected internal override ref (bool Archive, bool MaxDelta) IsPointToArchive(in DataPoint incoming, in DataPoint lastArchived)
         {
@@ -54,12 +50,12 @@ namespace gfoidl.DataCompression.Internal.SwingingDoor
         protected internal override void Init(int incomingIndex, in DataPoint incoming, ref int snapShotIndex) => throw new NotSupportedException();
         protected internal override void UpdateFilters(in DataPoint incoming, in DataPoint lastArchived)       => this.CloseTheDoor(incoming, lastArchived);
         //---------------------------------------------------------------------
-        protected override void ResetToInitialState()
+        protected override void DisposeCore()
         {
-            base.ResetToInitialState();
-
             _swingingDoorCompression = null;
             _slope                   = default;
+
+            base.DisposeCore();
         }
     }
 }

--- a/source/gfoidl.DataCompression/Compression/SwingingDoorCompression/SwingingDoorCompressionIterator.cs
+++ b/source/gfoidl.DataCompression/Compression/SwingingDoorCompression/SwingingDoorCompressionIterator.cs
@@ -1,5 +1,6 @@
 ﻿using System.Runtime.CompilerServices;
 using System;
+using System.Diagnostics;
 
 namespace gfoidl.DataCompression.Internal.SwingingDoor
 {
@@ -7,8 +8,8 @@ namespace gfoidl.DataCompression.Internal.SwingingDoor
     {
         protected static readonly (double Max, double Min) s_newDoor = (double.PositiveInfinity, double.NegativeInfinity);
         //---------------------------------------------------------------------
-        protected readonly SwingingDoorCompression _swingingDoorCompression;
-        protected (double Max, double Min)         _slope;
+        protected SwingingDoorCompression? _swingingDoorCompression;
+        protected (double Max, double Min) _slope;
         //---------------------------------------------------------------------
         protected SwingingDoorCompressionIterator(SwingingDoorCompression swingingDoorCompression)
             : base(swingingDoorCompression)
@@ -33,6 +34,8 @@ namespace gfoidl.DataCompression.Internal.SwingingDoor
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void CloseTheDoor(in DataPoint incoming, in DataPoint lastArchived)
         {
+            Debug.Assert(_swingingDoorCompression is not null);
+
             double upperSlope = lastArchived.Gradient(incoming,  _swingingDoorCompression.CompressionDeviation);
             double lowerSlope = lastArchived.Gradient(incoming, -_swingingDoorCompression.CompressionDeviation);
 
@@ -50,5 +53,13 @@ namespace gfoidl.DataCompression.Internal.SwingingDoor
         protected internal override void Init(in DataPoint incoming, ref DataPoint snapShot)                   => this.OpenNewDoor(incoming);
         protected internal override void Init(int incomingIndex, in DataPoint incoming, ref int snapShotIndex) => throw new NotSupportedException();
         protected internal override void UpdateFilters(in DataPoint incoming, in DataPoint lastArchived)       => this.CloseTheDoor(incoming, lastArchived);
+        //---------------------------------------------------------------------
+        protected override void ResetToInitialState()
+        {
+            base.ResetToInitialState();
+
+            _swingingDoorCompression = null;
+            _slope                   = default;
+        }
     }
 }

--- a/source/gfoidl.DataCompression/DataPointIndexedIterator.cs
+++ b/source/gfoidl.DataCompression/DataPointIndexedIterator.cs
@@ -9,14 +9,17 @@ namespace gfoidl.DataCompression
         where TList : notnull, IList<DataPoint>
     {
         private DataPointIterator? _wrapperIterator;
-        private TList              _list;
+        private TList?             _list;
         private int                _snapShotIndex;
         private int                _lastArchivedIndex;
         private int                _incomingIndex;
         //-----------------------------------------------------------------
-        public DataPointIndexedIterator(Compression compression, DataPointIterator wrappedIterator, TList source)
-            : base(compression)
+        public void SetData(Compression compression, DataPointIterator wrappedIterator, TList source)
         {
+            Debug.Assert(wrappedIterator is not null);
+            Debug.Assert(source          is not null);
+
+            this.SetData(compression);
             _wrapperIterator = wrappedIterator;
             _list            = source;
         }
@@ -25,12 +28,18 @@ namespace gfoidl.DataCompression
         {
             Debug.Assert(_algorithm       is not null);
             Debug.Assert(_wrapperIterator is not null);
+            Debug.Assert(_list            is not null);
 
-            return new DataPointIndexedIterator<TList>(_algorithm, _wrapperIterator, _list);
+            DataPointIndexedIterator<TList> clone = new();
+            clone.SetData(_algorithm, _wrapperIterator, _list);
+
+            return clone;
         }
         //-----------------------------------------------------------------
         public override bool MoveNext()
         {
+            Debug.Assert(_list is not null);
+
             switch (_state)
             {
                 case 0:
@@ -120,6 +129,8 @@ namespace gfoidl.DataCompression
         //---------------------------------------------------------------------
         public override DataPoint[] ToArray()
         {
+            Debug.Assert(_list is not null);
+
             TList source = _list;
 
             Debug.Assert(source.Count > 0);
@@ -134,6 +145,8 @@ namespace gfoidl.DataCompression
         //-----------------------------------------------------------------
         public override List<DataPoint> ToList()
         {
+            Debug.Assert(_list is not null);
+
             TList source = _list;
 
             Debug.Assert(source.Count > 0);
@@ -258,14 +271,14 @@ namespace gfoidl.DataCompression
             return incomingIndex;
         }
         //---------------------------------------------------------------------
-        protected override void ResetToInitialState()
+        protected override void DisposeCore()
         {
-            base.ResetToInitialState();
-
             _wrapperIterator   = null;
             _snapShotIndex     = -1;
             _lastArchivedIndex = -1;
             _incomingIndex     = -1;
+
+            base.DisposeCore();
         }
     }
 }

--- a/source/gfoidl.DataCompression/DataPointIndexedIterator.cs
+++ b/source/gfoidl.DataCompression/DataPointIndexedIterator.cs
@@ -122,7 +122,6 @@ namespace gfoidl.DataCompression
                     ThrowHelper.ThrowIfDisposed(ThrowHelper.ExceptionArgument.iterator);
                     return false;
                 default:
-                    this.Dispose();
                     return false;
             }
         }
@@ -273,7 +272,12 @@ namespace gfoidl.DataCompression
         //---------------------------------------------------------------------
         protected override void DisposeCore()
         {
-            _wrapperIterator   = null;
+            if (_wrapperIterator is not null)
+            {
+                _wrapperIterator.Dispose();
+                _wrapperIterator = null;
+            }
+
             _snapShotIndex     = -1;
             _lastArchivedIndex = -1;
             _incomingIndex     = -1;

--- a/source/gfoidl.DataCompression/DataPointIterator.Async.cs
+++ b/source/gfoidl.DataCompression/DataPointIterator.Async.cs
@@ -45,7 +45,8 @@ namespace gfoidl.DataCompression
         //---------------------------------------------------------------------
         private async IAsyncEnumerator<DataPoint> IterateCore(CancellationToken cancellationToken)
         {
-            Debug.Assert(_asyncSource != null);
+            Debug.Assert(_algorithm   is not null);
+            Debug.Assert(_asyncSource is not null);
 
             cancellationToken.ThrowIfCancellationRequested();
 

--- a/source/gfoidl.DataCompression/DataPointIterator.Async.cs
+++ b/source/gfoidl.DataCompression/DataPointIterator.Async.cs
@@ -8,7 +8,20 @@ namespace gfoidl.DataCompression
 {
     public abstract partial class DataPointIterator : IAsyncEnumerable<DataPoint>
     {
-        private protected IAsyncEnumerable<DataPoint>? _asyncSource;
+#pragma warning disable CS1591
+        protected IAsyncEnumerable<DataPoint>? _asyncSource;
+#pragma warning restore CS1591
+        //---------------------------------------------------------------------
+        /// <summary>
+        /// Sets the algorithm for this <see cref="DataPointIterator" />.
+        /// </summary>
+        protected internal void SetData(Compression algorithm, IAsyncEnumerable<DataPoint> data)
+        {
+            if (data is null) ThrowHelper.ThrowArgumentNull(ThrowHelper.ExceptionArgument.data);
+
+            this.SetData(algorithm);
+            _asyncSource = data;
+        }
         //---------------------------------------------------------------------
         /// <summary>
         /// Gets an enumerator for the <see cref="DataPoint" />s.

--- a/source/gfoidl.DataCompression/DataPointIterator.Enumerable.cs
+++ b/source/gfoidl.DataCompression/DataPointIterator.Enumerable.cs
@@ -152,6 +152,8 @@ namespace gfoidl.DataCompression
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private ref DataPoint HandleSkipMinDeltaX(IEnumerator<DataPoint> enumerator, ref DataPoint incoming, double snapShotX)
         {
+            Debug.Assert(_algorithm is not null);
+
             if (_algorithm._minDeltaXHasValue)
             {
                 this.SkipMinDeltaX(enumerator, ref incoming, snapShotX);
@@ -163,6 +165,8 @@ namespace gfoidl.DataCompression
         [MethodImpl(MethodImplOptions.NoInlining)]
         private void SkipMinDeltaX(IEnumerator<DataPoint> enumerator, ref DataPoint incoming, double snapShotX)
         {
+            Debug.Assert(_algorithm is not null);
+
             double minDeltaX = _algorithm._minDeltaX;
 
             while (enumerator.MoveNext())

--- a/source/gfoidl.DataCompression/DataPointIterator.Enumerable.cs
+++ b/source/gfoidl.DataCompression/DataPointIterator.Enumerable.cs
@@ -13,6 +13,18 @@ namespace gfoidl.DataCompression
 #pragma warning restore CS1591
         //---------------------------------------------------------------------
         /// <summary>
+        /// Sets the algorithm for this <see cref="DataPointIterator" />.
+        /// </summary>
+        protected internal void SetData(Compression algorithm, IEnumerable<DataPoint> data)
+        {
+            if (data is null) ThrowHelper.ThrowArgumentNull(ThrowHelper.ExceptionArgument.data);
+
+            this.SetData(algorithm);
+            _source     = data;
+            _enumerator = data.GetEnumerator();
+        }
+        //---------------------------------------------------------------------
+        /// <summary>
         /// Advances the enumerator to the next element.
         /// </summary>
         /// <returns>
@@ -75,7 +87,6 @@ namespace gfoidl.DataCompression
                     ThrowHelper.ThrowIfDisposed(ThrowHelper.ExceptionArgument.iterator);
                     return false;
                 default:
-                    this.Dispose();
                     return false;
             }
         }

--- a/source/gfoidl.DataCompression/DataPointIterator.cs
+++ b/source/gfoidl.DataCompression/DataPointIterator.cs
@@ -43,6 +43,7 @@ namespace gfoidl.DataCompression
         {
             if (algorithm is null) ThrowHelper.ThrowArgumentNull(ThrowHelper.ExceptionArgument.algorithm);
 
+            _state     = InitialState;
             _threadId  = Environment.CurrentManagedThreadId;
             _algorithm = algorithm;
         }

--- a/source/gfoidl.DataCompression/EmptyDataPointIterator.cs
+++ b/source/gfoidl.DataCompression/EmptyDataPointIterator.cs
@@ -7,8 +7,6 @@ namespace gfoidl.DataCompression
 {
     internal sealed class EmptyDataPointIterator : DataPointIterator
     {
-        public EmptyDataPointIterator(Compression compression) : base(compression) { }
-        //---------------------------------------------------------------------
         public override DataPointIterator Clone() => this;
         public override bool MoveNext()           => false;
         public override DataPoint[] ToArray()     => Array.Empty<DataPoint>();

--- a/source/gfoidl.DataCompression/InternalsVisibleTo.cs
+++ b/source/gfoidl.DataCompression/InternalsVisibleTo.cs
@@ -1,3 +1,0 @@
-﻿using System.Runtime.CompilerServices;
-
-[assembly: InternalsVisibleTo("gfoidl.DataCompression.Tests")]

--- a/source/gfoidl.DataCompression/ThrowHelper.cs
+++ b/source/gfoidl.DataCompression/ThrowHelper.cs
@@ -41,6 +41,7 @@ namespace gfoidl.DataCompression
         //---------------------------------------------------------------------
         public enum ExceptionArgument
         {
+            algorithm,
             data,
             iterator
         }

--- a/source/gfoidl.DataCompression/gfoidl.DataCompression.csproj
+++ b/source/gfoidl.DataCompression/gfoidl.DataCompression.csproj
@@ -32,6 +32,10 @@
     </ItemGroup>
 
     <ItemGroup>
+        <InternalsVisibleTo Include="gfoidl.DataCompression.Tests" />
+    </ItemGroup>
+
+    <ItemGroup>
         <Compile Update="Strings.Designer.cs">
             <DesignTime>True</DesignTime>
             <AutoGen>True</AutoGen>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -3,7 +3,7 @@
     <Import Project="../Directory.Build.props" />
 
     <PropertyGroup>
-        <DeveloperBuildTestTfms>netcoreapp3.1</DeveloperBuildTestTfms>
+        <DeveloperBuildTestTfms>net5.0</DeveloperBuildTestTfms>
         <StandardTestTfms>$(DeveloperBuildTestTfms)</StandardTestTfms>
         <StandardTestTfms Condition="'$(OS)' == 'Windows_NT'">$(StandardTestTfms);net48</StandardTestTfms>
     </PropertyGroup>

--- a/tests/gfoidl.DataCompression.Tests/Compression/DeadBandCompressionTests/IteratorCaching.cs
+++ b/tests/gfoidl.DataCompression.Tests/Compression/DeadBandCompressionTests/IteratorCaching.cs
@@ -1,0 +1,100 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+
+namespace gfoidl.DataCompression.Tests.Compression.DeadBandCompressionTests
+{
+    public class IteratorCaching : Base
+    {
+        [Test]
+        public void Data_given_as_IEnumerable___OK()
+        {
+            var sut      = new DeadBandCompression(0.1);
+            var data     = RawDataForTrend();
+            var expected = ExpectedForTrend().ToList();
+
+            var actual0 = new List<DataPoint>();
+            foreach (DataPoint dp in sut.Process(data))
+                actual0.Add(dp);
+
+            var actual1 = new List<DataPoint>();
+            foreach (DataPoint dp in sut.Process(data))
+                actual1.Add(dp);
+
+            CollectionAssert.AreEqual(expected, actual0);
+            CollectionAssert.AreEqual(expected, actual1);
+        }
+        //---------------------------------------------------------------------
+        [Test]
+        public void Iterator_Caching_IEnumerable___same_Instance()
+        {
+            var sut   = new DeadBandCompression(0.1);
+            var data  = RawDataForTrend();
+            var dummy = new List<DataPoint>();
+
+            DataPointIterator actual0 = sut.Process(data.Skip(1));
+            foreach (DataPoint dp in actual0)
+                dummy.Add(dp);
+
+            DataPointIterator actual1 = sut.Process(data.Take(1));
+            foreach (DataPoint dp in actual1)
+                dummy.Add(dp);
+
+            Assert.AreSame(actual0, actual1);
+        }
+        //---------------------------------------------------------------------
+        [Test]
+        public void Iterator_Caching_List___same_Instance()
+        {
+            var sut   = new DeadBandCompression(0.1);
+            var data  = RawDataForTrend();
+            var dummy = new List<DataPoint>();
+
+            DataPointIterator actual0 = sut.Process(data.Skip(1).ToList());
+            foreach (DataPoint dp in actual0)
+                dummy.Add(dp);
+
+            DataPointIterator actual1 = sut.Process(data.Take(1).ToList());
+            foreach (DataPoint dp in actual1)
+                dummy.Add(dp);
+
+            Assert.AreSame(actual0, actual1);
+        }
+        //---------------------------------------------------------------------
+        [Test]
+        public void Iterator_Caching_IList___same_Instance()
+        {
+            var sut   = new DeadBandCompression(0.1);
+            var data  = RawDataForTrend();
+            var dummy = new List<DataPoint>();
+
+            DataPointIterator actual0 = sut.Process(data.Skip(1).ToList().AsReadOnly());
+            foreach (DataPoint dp in actual0)
+                dummy.Add(dp);
+
+            DataPointIterator actual1 = sut.Process(data.Take(1).ToList().AsReadOnly());
+            foreach (DataPoint dp in actual1)
+                dummy.Add(dp);
+
+            Assert.AreSame(actual0, actual1);
+        }
+        //---------------------------------------------------------------------
+        [Test]
+        public void Iterator_Caching_Array___same_Instance()
+        {
+            var sut   = new DeadBandCompression(0.1);
+            var data  = RawDataForTrend();
+            var dummy = new List<DataPoint>();
+
+            DataPointIterator actual0 = sut.Process(data.Skip(1).ToArray());
+            foreach (DataPoint dp in actual0)
+                dummy.Add(dp);
+
+            DataPointIterator actual1 = sut.Process(data.Take(1).ToArray());
+            foreach (DataPoint dp in actual1)
+                dummy.Add(dp);
+
+            Assert.AreSame(actual0, actual1);
+        }
+    }
+}

--- a/tests/gfoidl.DataCompression.Tests/Compression/SwingingDoorCompressionTests/IteratorCaching.cs
+++ b/tests/gfoidl.DataCompression.Tests/Compression/SwingingDoorCompressionTests/IteratorCaching.cs
@@ -1,0 +1,100 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+
+namespace gfoidl.DataCompression.Tests.Compression.SwingingDoorCompressionTests
+{
+    public class IteratorCaching : Base
+    {
+        [Test]
+        public void Data_given_as_IEnumerable___OK()
+        {
+            var sut      = new SwingingDoorCompression(1);
+            var data     = RawDataForTrend();
+            var expected = ExpectedForTrend().ToList();
+
+            var actual0 = new List<DataPoint>();
+            foreach (DataPoint dp in sut.Process(data))
+                actual0.Add(dp);
+
+            var actual1 = new List<DataPoint>();
+            foreach (DataPoint dp in sut.Process(data))
+                actual1.Add(dp);
+
+            CollectionAssert.AreEqual(expected, actual0);
+            CollectionAssert.AreEqual(expected, actual1);
+        }
+        //---------------------------------------------------------------------
+        [Test]
+        public void Iterator_Caching_IEnumerable___same_Instance()
+        {
+            var sut   = new SwingingDoorCompression(1);
+            var data  = RawDataForTrend();
+            var dummy = new List<DataPoint>();
+
+            DataPointIterator actual0 = sut.Process(data.Skip(1));
+            foreach (DataPoint dp in actual0)
+                dummy.Add(dp);
+
+            DataPointIterator actual1 = sut.Process(data.Take(1));
+            foreach (DataPoint dp in actual1)
+                dummy.Add(dp);
+
+            Assert.AreSame(actual0, actual1);
+        }
+        //---------------------------------------------------------------------
+        [Test]
+        public void Iterator_Caching_List___same_Instance()
+        {
+            var sut   = new SwingingDoorCompression(1);
+            var data  = RawDataForTrend();
+            var dummy = new List<DataPoint>();
+
+            DataPointIterator actual0 = sut.Process(data.Skip(1).ToList());
+            foreach (DataPoint dp in actual0)
+                dummy.Add(dp);
+
+            DataPointIterator actual1 = sut.Process(data.Take(1).ToList());
+            foreach (DataPoint dp in actual1)
+                dummy.Add(dp);
+
+            Assert.AreSame(actual0, actual1);
+        }
+        //---------------------------------------------------------------------
+        [Test]
+        public void Iterator_Caching_IList___same_Instance()
+        {
+            var sut   = new SwingingDoorCompression(1);
+            var data  = RawDataForTrend();
+            var dummy = new List<DataPoint>();
+
+            DataPointIterator actual0 = sut.Process(data.Skip(1).ToList().AsReadOnly());
+            foreach (DataPoint dp in actual0)
+                dummy.Add(dp);
+
+            DataPointIterator actual1 = sut.Process(data.Take(1).ToList().AsReadOnly());
+            foreach (DataPoint dp in actual1)
+                dummy.Add(dp);
+
+            Assert.AreSame(actual0, actual1);
+        }
+        //---------------------------------------------------------------------
+        [Test]
+        public void Iterator_Caching_Array___same_Instance()
+        {
+            var sut   = new SwingingDoorCompression(1);
+            var data  = RawDataForTrend();
+            var dummy = new List<DataPoint>();
+
+            DataPointIterator actual0 = sut.Process(data.Skip(1).ToArray());
+            foreach (DataPoint dp in actual0)
+                dummy.Add(dp);
+
+            DataPointIterator actual1 = sut.Process(data.Take(1).ToArray());
+            foreach (DataPoint dp in actual1)
+                dummy.Add(dp);
+
+            Assert.AreSame(actual0, actual1);
+        }
+    }
+}


### PR DESCRIPTION
## Description

Made the creation of the `DataPointIterator`s amortized allocation free.

Usage patterns like
```c#
DeadBandCompression deadBand         = new DeadBandCompression(0.1);
SwingingDoorCompression swingingDoor = new SwingingDoorCompression(0.1);

while (...)
{
    DataPointIterator deadBandCompressed     = deadBand.Process(rawDataPoints);
    DataPointIterator swingingDoorCompressed = swingingDoor.Process(deadBandCompressed);

    foreach (DataPoint item in swingingDoorCompressed)
    {
        compressed.Add(item);
    }
}
```
where the iterator is created in a loop itself, it's now without further allocations.

## Results

### Before

![grafik](https://user-images.githubusercontent.com/5755834/101844008-b1698280-3b4b-11eb-9d50-7a1a6ae3970e.png)

```
|             Method |    n |         Mean |         Error |       StdDev |    Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------- |----- |-------------:|--------------:|-------------:|---------:|------:|------:|----------:|
|    SingleIteration |    ? |     119.4 ns |      35.37 ns |      1.94 ns |   0.1018 |     - |     - |     320 B |
| MultipleIterations |  100 |  14,547.9 ns |   9,871.65 ns |    541.10 ns |  10.1929 |     - |     - |   32000 B |
| MultipleIterations | 1000 | 147,214.0 ns | 309,726.03 ns | 16,977.13 ns | 101.8066 |     - |     - |  320000 B |
```
[this benchmark](https://github.com/gfoidl/DataCompression/blob/fd84b257b5aaed967c7abe3db4d4771ca103f3bd/perf/gfoidl.DataCompression.Benchmarks/IteratorInstantiatonBenchmark.cs#L10)

A perfect O(n).

### After

![grafik](https://user-images.githubusercontent.com/5755834/101844055-dbbb4000-3b4b-11eb-8959-a7947fa27920.png)

```
|             Method |    n |         Mean |         Error |       StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------- |----- |-------------:|--------------:|-------------:|------:|------:|------:|----------:|
|    SingleIteration |    ? |     110.7 ns |      93.31 ns |      5.11 ns |     - |     - |     - |         - |
| MultipleIterations |  100 |  10,772.9 ns |   8,084.66 ns |    443.15 ns |     - |     - |     - |         - |
| MultipleIterations | 1000 | 129,554.4 ns | 536,653.22 ns | 29,415.77 ns |     - |     - |     - |         - |
```
[this benchmark](https://github.com/gfoidl/DataCompression/blob/fd84b257b5aaed967c7abe3db4d4771ca103f3bd/perf/gfoidl.DataCompression.Benchmarks/IteratorInstantiatonBenchmark.cs#L10)